### PR TITLE
Add timeout selection panel

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -141,6 +141,23 @@
         </Style>
         <Style x:Key="TimeOut" TargetType="Button" BasedOn="{StaticResource BaseActionButtonStyle}">
         </Style>
+        <!-- TEAM A TIMEOUT BUTTON -->
+        <Style x:Key="TeamATimeoutStyle" TargetType="Button" BasedOn="{StaticResource BaseActionButtonStyle}">
+            <Setter Property="Background" Value="{StaticResource CourtAColor}" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Width" Value="120" />
+            <Setter Property="Height" Value="80" />
+        </Style>
+
+        <!-- TEAM B TIMEOUT BUTTON -->
+        <Style x:Key="TeamBTimeoutStyle" TargetType="Button" BasedOn="{StaticResource BaseActionButtonStyle}">
+            <Setter Property="Background" Value="{StaticResource CourtBColor}" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Width" Value="120" />
+            <Setter Property="Height" Value="80" />
+        </Style>
 
         <Style x:Key="SubButtonStyle" TargetType="Button" BasedOn="{StaticResource BasePlayerButtonStyle}">
             <Setter Property="Background" Value="White"/>
@@ -701,6 +718,16 @@ Margin="4" />
                         </ItemsControl>
                     </StackPanel>
                 </Grid>
+                <!-- Timeout Panel -->
+                <Grid Visibility="{Binding TimeOutPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                        <TextBlock Text="Select Team for Timeout" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Button Content="Team A" Style="{StaticResource TeamATimeoutStyle}" Command="{Binding TimeoutTeamACommand}" Margin="5"/>
+                            <Button Content="Team B" Style="{StaticResource TeamBTimeoutStyle}" Command="{Binding TimeoutTeamBCommand}" Margin="5"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
                 <!-- Substitution Panel -->
                 <Grid Visibility="{Binding SubstitutionPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
                     <StackPanel HorizontalAlignment="Center"
@@ -981,7 +1008,8 @@ Grid.Column="4" />
             Style="{StaticResource Sub}"
             Content="SUB"
             Command="{Binding StartSubstitutionCommand}" />
-                <Button Grid.Column="2" Style="{StaticResource TimeOut}" Content="TIME OUT" />
+                <Button Grid.Column="2" Style="{StaticResource TimeOut}" Content="TIME OUT"
+                        Command="{Binding StartTimeoutCommand}" />
 
             </Grid>
         </Grid>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -53,6 +53,20 @@ public class MainWindowViewModel : ViewModelBase
     public Visibility SubstitutionPanelVisibility =>
         IsSubstitutionPanelVisible ? Visibility.Visible : Visibility.Collapsed;
 
+    private bool _isTimeOutSelectionActive;
+    public bool IsTimeOutSelectionActive
+    {
+        get => _isTimeOutSelectionActive;
+        set
+        {
+            _isTimeOutSelectionActive = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TimeOutPanelVisibility));
+        }
+    }
+    public Visibility TimeOutPanelVisibility =>
+        IsTimeOutSelectionActive ? Visibility.Visible : Visibility.Collapsed;
+
     private readonly ResourceDictionary _resources;
 
     public ICommand SelectActionCommand { get; }
@@ -70,6 +84,9 @@ public class MainWindowViewModel : ViewModelBase
     public ICommand ConfirmSubstitutionCommand { get; }
     public ICommand ToggleSubInCommand { get; }
     public ICommand ToggleSubOutCommand { get; }
+    public ICommand StartTimeoutCommand { get; }
+    public ICommand TimeoutTeamACommand { get; }
+    public ICommand TimeoutTeamBCommand { get; }
 
 
     public event Action<Point, Brush, bool>? MarkerRequested;
@@ -116,6 +133,9 @@ public class MainWindowViewModel : ViewModelBase
         ConfirmSubstitutionCommand = new RelayCommand(_ => ConfirmSubstitution(), _ => IsSubstitutionConfirmEnabled);
         ToggleSubInCommand = new RelayCommand(p => ToggleSubIn(p as Player));
         ToggleSubOutCommand = new RelayCommand(p => ToggleSubOut(p as Player));
+        StartTimeoutCommand = new RelayCommand(_ => BeginTimeout());
+        TimeoutTeamACommand = new RelayCommand(_ => CompleteTimeoutSelection("Team A"), _ => IsTimeOutSelectionActive);
+        TimeoutTeamBCommand = new RelayCommand(_ => CompleteTimeoutSelection("Team B"), _ => IsTimeOutSelectionActive);
 
 
         Players.CollectionChanged += Players_CollectionChanged;
@@ -131,6 +151,17 @@ public class MainWindowViewModel : ViewModelBase
         TeamBSubOut.Clear();
 
         IsSubstitutionPanelVisible = true;
+    }
+
+    private void BeginTimeout()
+    {
+        IsTimeOutSelectionActive = true;
+    }
+
+    private void CompleteTimeoutSelection(string team)
+    {
+        Debug.WriteLine($"Timeout called by {team}");
+        IsTimeOutSelectionActive = false;
     }
 
     private void SelectAction(string? action)
@@ -198,7 +229,7 @@ public class MainWindowViewModel : ViewModelBase
 
             if (_foulType?.ToLowerInvariant() == "offensive")
             {
-                Debug.WriteLine($"Offensive foul by {_foulCommiter?.Number}.{_foulCommiter?.Name} on {_fouledPlayer?.Number}.{_fouledPlayer?.Name} — no free throws");
+                Debug.WriteLine($"Offensive foul by {_foulCommiter?.Number}.{_foulCommiter?.Name} on {_fouledPlayer?.Number}.{_fouledPlayer?.Name} â€” no free throws");
                 ResetFoulState();
             }
             else
@@ -360,7 +391,7 @@ public class MainWindowViewModel : ViewModelBase
             if (assistPlayer?.Number == _pendingShooter.Number)
             {
                 // Invalid: same player attempted to get an assist
-                Debug.WriteLine("Assist not awarded — shooter cannot assist their own shot.");
+                Debug.WriteLine("Assist not awarded â€” shooter cannot assist their own shot.");
             }
             else
             {


### PR DESCRIPTION
## Summary
- add timeout panel styles for Team A and Team B
- show timeout selection dialog with team‑colored buttons
- log which team called timeout via Debug output
- wire new timeout commands to button

## Testing
- `dotnet build StatsBB.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbfa9f11c83269ff14ac4334d0272