### PR TITLE
Add scoreboard bindings for team cards

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -285,7 +285,7 @@
                         <RowDefinition Height="2*"/>
                     </Grid.RowDefinitions>
                     <Rectangle Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Fill="Orange" RadiusX="4" RadiusY="4"/>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Text="Team A" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding TeamAName}" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0"/>
                     <Grid Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -294,7 +294,7 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right">
                             <Border Background="#EEE" CornerRadius="3" Padding="4" Margin="4,0,4,0">
-                                <TextBlock Text="3/3" FontSize="20" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding TeamATimeoutsText}" FontSize="20" FontWeight="Bold"/>
                             </Border>
                         </StackPanel>
                         <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0">
@@ -306,7 +306,7 @@
                         </StackPanel>
                     </Grid>
                     <Border Grid.RowSpan="2" Grid.Column="2" BorderBrush="#888" CornerRadius="0"  BorderThickness="1,0,0,0">
-                        <TextBlock Text="199" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                        <TextBlock Text="{Binding TeamAScore}" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </Border>
                 </Grid>
             </Border>
@@ -327,9 +327,9 @@
                         <RowDefinition Height="2*"/>
                     </Grid.RowDefinitions>
                     <Border Grid.RowSpan="2" Grid.Column="0" BorderBrush="#888" CornerRadius="0" BorderThickness="0,0,1,0">
-                        <TextBlock Text="199" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                        <TextBlock Text="{Binding TeamBScore}" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </Border>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Text="Team B" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,8,0"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Text="{Binding TeamBName}" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,8,0"/>
                     <Rectangle Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" Fill="Green" RadiusX="4" RadiusY="4"/>
 
                     <Grid Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch">
@@ -347,7 +347,7 @@
                         </StackPanel>
                         <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Border Background="#EEE" CornerRadius="3" Padding="4" Margin="4,0,4,0">
-                                <TextBlock Text="3/3" FontSize="20" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding TeamBTimeoutsText}" FontSize="20" FontWeight="Bold"/>
                             </Border>
                         </StackPanel>
                     </Grid>

--- a/StatsBB/UserControls/TeamCardLeft.xaml
+++ b/StatsBB/UserControls/TeamCardLeft.xaml
@@ -16,7 +16,7 @@
                 <RowDefinition Height="2*"/>
             </Grid.RowDefinitions>
             <Rectangle Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Fill="Orange" RadiusX="4" RadiusY="4"/>
-            <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Text="Team A" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding TeamAName}" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0"/>
             <Grid Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -25,7 +25,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right">
                     <Border Background="#EEE" CornerRadius="3" Padding="4" Margin="4,0,4,0">
-                        <TextBlock Text="3/3" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding TeamATimeoutsText}" FontSize="20" FontWeight="Bold"/>
                     </Border>
                 </StackPanel>
                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0">
@@ -37,7 +37,7 @@
                 </StackPanel>
             </Grid>
             <Border Grid.RowSpan="2" Grid.Column="2" BorderBrush="#888" CornerRadius="0"  BorderThickness="1,0,0,0">
-                <TextBlock Text="199" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TeamAScore}" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
             </Border>
         </Grid>
     </Border>

--- a/StatsBB/UserControls/TeamCardRight.xaml
+++ b/StatsBB/UserControls/TeamCardRight.xaml
@@ -20,9 +20,9 @@
                 <RowDefinition Height="2*"/>
             </Grid.RowDefinitions>
             <Border Grid.RowSpan="2" Grid.Column="0" BorderBrush="#888" CornerRadius="0" BorderThickness="0,0,1,0">
-                <TextBlock Text="199" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TeamBScore}" FontSize="52" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
             </Border>
-            <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Text="Team B" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,8,0"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Text="{Binding TeamBName}" FontWeight="Bold" FontSize="32" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,8,0"/>
             <Rectangle Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" Fill="Green" RadiusX="4" RadiusY="4"/>
 
             <Grid Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch">
@@ -40,7 +40,7 @@
                 </StackPanel>
                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Border Background="#EEE" CornerRadius="3" Padding="4" Margin="4,0,4,0">
-                        <TextBlock Text="3/3" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding TeamBTimeoutsText}" FontSize="20" FontWeight="Bold"/>
                     </Border>
                 </StackPanel>
             </Grid>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -51,6 +51,102 @@ public class MainWindowViewModel : ViewModelBase
     public ObservableCollection<Player> TeamBBenchPlayers =>
         new(Players.Where(p => !p.IsTeamA && !p.IsActive));
 
+    private string _teamAName = "Team A";
+    public string TeamAName
+    {
+        get => _teamAName;
+        set
+        {
+            _teamAName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private string _teamBName = "Team B";
+    public string TeamBName
+    {
+        get => _teamBName;
+        set
+        {
+            _teamBName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private int _teamAScore;
+    public int TeamAScore
+    {
+        get => _teamAScore;
+        set
+        {
+            _teamAScore = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private int _teamBScore;
+    public int TeamBScore
+    {
+        get => _teamBScore;
+        set
+        {
+            _teamBScore = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private int _teamATimeOutsLeft = 3;
+    public int TeamATimeOutsLeft
+    {
+        get => _teamATimeOutsLeft;
+        set
+        {
+            _teamATimeOutsLeft = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TeamATimeoutsText));
+        }
+    }
+
+    private int _teamATotalTimeouts = 3;
+    public int TeamATotalTimeouts
+    {
+        get => _teamATotalTimeouts;
+        set
+        {
+            _teamATotalTimeouts = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TeamATimeoutsText));
+        }
+    }
+
+    public string TeamATimeoutsText => $"{TeamATimeOutsLeft}/{TeamATotalTimeouts}";
+
+    private int _teamBTimeOutsLeft = 3;
+    public int TeamBTimeOutsLeft
+    {
+        get => _teamBTimeOutsLeft;
+        set
+        {
+            _teamBTimeOutsLeft = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TeamBTimeoutsText));
+        }
+    }
+
+    private int _teamBTotalTimeouts = 3;
+    public int TeamBTotalTimeouts
+    {
+        get => _teamBTotalTimeouts;
+        set
+        {
+            _teamBTotalTimeouts = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(TeamBTimeoutsText));
+        }
+    }
+
+    public string TeamBTimeoutsText => $"{TeamBTimeOutsLeft}/{TeamBTotalTimeouts}";
+
     private bool _isSubstitutionPanelVisible;
     public bool IsSubstitutionPanelVisible
     {


### PR DESCRIPTION
## Summary
- introduce properties for team names, scores and timeouts in `MainWindowViewModel`
- bind team card values in `MainWindow.xaml` to the new view model properties
- update `TeamCardLeft` and `TeamCardRight` user controls to use the bindings

## Testing
- `dotnet build StatsBB.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf127f54c83268c8ca5f497ef6d56