### PR TITLE
Add play by play mapping

### DIFF
--- a/StatsBB.Tests/PlayByPlayViewModelTests.cs
+++ b/StatsBB.Tests/PlayByPlayViewModelTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using StatsBB.Model;
+using StatsBB.ViewModel;
+using Xunit;
+
+public class PlayByPlayViewModelTests
+{
+    private readonly Dictionary<int, PlayerInfo> _players = new()
+    {
+        { 23, new PlayerInfo { Id = 23, Name = "Jones", Number = 23 } },
+        { 5, new PlayerInfo { Id = 5, Name = "Smith", Number = 5 } }
+    };
+
+    [Fact]
+    public void Map_MadeThreePointShot()
+    {
+        var play = new PlayByPlay
+        {
+            Id = 1,
+            OrderNumber = 27,
+            Clock = "06:12",
+            Period = Period.Q2,
+            Team = TeamSelect.TeamA,
+            Player = 23,
+            PlayType = PlayType.FieldGoal,
+            Flags = new() { "made", "3pt" },
+            Point = new Point { Value = 3 },
+            ScoreChange = true,
+            TeamA = new StatsSnapshot { Score = 58 },
+            TeamB = new StatsSnapshot { Score = 54 }
+        };
+
+        var vm = PlayByPlayViewModel.Map(play, _players);
+        Assert.Equal(27, vm.Sequence);
+        Assert.True(vm.IsMadeShot);
+        Assert.Equal(3, vm.Points);
+        Assert.Equal("58\u201354", vm.ScoreAfter);
+        Assert.Equal("Jones", vm.PlayerName);
+    }
+
+    [Fact]
+    public void Map_MissedFreeThrow()
+    {
+        var play = new PlayByPlay
+        {
+            Id = 2,
+            OrderNumber = 30,
+            Clock = "02:10",
+            Period = Period.Q1,
+            Team = TeamSelect.TeamB,
+            Player = 5,
+            PlayType = PlayType.FreeThrow,
+            Flags = new() { "missed" },
+            Point = new Point { Value = 0 },
+            ScoreChange = false,
+            TeamA = new StatsSnapshot { Score = 10 },
+            TeamB = new StatsSnapshot { Score = 12 }
+        };
+
+        var vm = PlayByPlayViewModel.Map(play, _players);
+        Assert.True(vm.IsFreeThrow);
+        Assert.False(vm.IsMadeShot);
+        Assert.Equal(0, vm.Points);
+    }
+
+    [Fact]
+    public void Map_Rebound_Turnover()
+    {
+        var rebound = new PlayByPlay
+        {
+            Id = 3,
+            OrderNumber = 40,
+            Clock = "01:15",
+            Period = Period.Q3,
+            Team = TeamSelect.TeamA,
+            Player = 23,
+            PlayType = PlayType.Rebound,
+            Flags = new() { "offensive" },
+            Point = new Point { Value = 0 },
+            ScoreChange = false,
+            TeamA = new StatsSnapshot { Score = 70 },
+            TeamB = new StatsSnapshot { Score = 65 }
+        };
+        var reboundVm = PlayByPlayViewModel.Map(rebound, _players);
+        Assert.True(reboundVm.IsRebound);
+
+        var turnover = new PlayByPlay
+        {
+            Id = 4,
+            OrderNumber = 41,
+            Clock = "01:10",
+            Period = Period.Q3,
+            Team = TeamSelect.TeamA,
+            Player = 23,
+            PlayType = PlayType.Turnover,
+            Flags = new(),
+            PossessionSwitch = true,
+            Point = new Point { Value = 0 },
+            ScoreChange = false,
+            TeamA = new StatsSnapshot { Score = 70 },
+            TeamB = new StatsSnapshot { Score = 65 }
+        };
+        var turnoverVm = PlayByPlayViewModel.Map(turnover, _players);
+        Assert.True(turnoverVm.IsTurnover);
+        Assert.True(turnoverVm.PossessionChange);
+    }
+
+    [Fact]
+    public void Map_Foul_Substitution()
+    {
+        var foul = new PlayByPlay
+        {
+            Id = 5,
+            OrderNumber = 50,
+            Clock = "05:00",
+            Period = Period.Q4,
+            Team = TeamSelect.TeamB,
+            Player = 5,
+            PlayType = PlayType.Foul,
+            Flags = new(),
+            Point = new Point { Value = 0 },
+            ScoreChange = false,
+            TeamA = new StatsSnapshot { Score = 80 },
+            TeamB = new StatsSnapshot { Score = 82 }
+        };
+        var foulVm = PlayByPlayViewModel.Map(foul, _players);
+        Assert.Equal("Smith", foulVm.PlayerName);
+        Assert.Equal(PlayType.Foul, foul.PlayType);
+
+        var sub = new PlayByPlay
+        {
+            Id = 6,
+            OrderNumber = 51,
+            Clock = "04:50",
+            Period = Period.Q4,
+            Team = TeamSelect.TeamB,
+            Player = 5,
+            PlayType = PlayType.Substitution,
+            Flags = new(),
+            Point = new Point { Value = 0 },
+            ScoreChange = false,
+            TeamA = new StatsSnapshot { Score = 80 },
+            TeamB = new StatsSnapshot { Score = 82 }
+        };
+        var subVm = PlayByPlayViewModel.Map(sub, _players);
+        Assert.Equal("Smith", subVm.PlayerName);
+        Assert.Equal(PlayType.Substitution, sub.PlayType);
+    }
+
+    [Fact]
+    public void Map_ScoreChange_PossessionArrow()
+    {
+        var play = new PlayByPlay
+        {
+            Id = 7,
+            OrderNumber = 60,
+            Clock = "03:00",
+            Period = Period.OT1,
+            Team = TeamSelect.TeamA,
+            Player = 23,
+            PlayType = PlayType.FieldGoal,
+            Flags = new() { "made" },
+            Point = new Point { Value = 2 },
+            ScoreChange = true,
+            PossessionSwitch = true,
+            ArrowSwitch = true,
+            TeamA = new StatsSnapshot { Score = 90 },
+            TeamB = new StatsSnapshot { Score = 88 }
+        };
+        var vm = PlayByPlayViewModel.Map(play, _players);
+        Assert.True(vm.IsScoreChange);
+        Assert.True(vm.PossessionChange);
+        Assert.True(vm.ArrowSwitch);
+    }
+}

--- a/StatsBB.Tests/StatsBB.Tests.csproj
+++ b/StatsBB.Tests/StatsBB.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StatsBB\StatsBB.csproj" />
+  </ItemGroup>
+</Project>

--- a/StatsBB.sln
+++ b/StatsBB.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatsBB", "StatsBB\StatsBB.csproj", "{8432ABF5-CF03-4957-A2B6-94D2863C3AE3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatsBB.Tests", "StatsBB.Tests\StatsBB.Tests.csproj", "{D11819ED-7B8E-4F6B-B461-5CC3FA1D4DB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{8432ABF5-CF03-4957-A2B6-94D2863C3AE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8432ABF5-CF03-4957-A2B6-94D2863C3AE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8432ABF5-CF03-4957-A2B6-94D2863C3AE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8432ABF5-CF03-4957-A2B6-94D2863C3AE3}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {8432ABF5-CF03-4957-A2B6-94D2863C3AE3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D11819ED-7B8E-4F6B-B461-5CC3FA1D4DB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D11819ED-7B8E-4F6B-B461-5CC3FA1D4DB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D11819ED-7B8E-4F6B-B461-5CC3FA1D4DB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D11819ED-7B8E-4F6B-B461-5CC3FA1D4DB0}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/StatsBB/Model/PlayByPlay.cs
+++ b/StatsBB/Model/PlayByPlay.cs
@@ -1,48 +1,71 @@
-﻿namespace StatsBB.Model
+namespace StatsBB.Model;
+
+/// <summary>
+/// Represents a raw play-by-play event coming from the live game feed.
+/// </summary>
+public class PlayByPlay
 {
-    public class PlayByPlay
-    {
-        public int Id { get; set; }
-        public int Period { get; set; }
-        public string Time { get; set; }
-        public bool TeamA {  get; set; }
-        public int PlayerNumer { get; set; }
-        public string PlayerName { get; set; }
-        public bool IsTeamAction { get; set; }
-        public bool IsGameAction { get; set; }
-        public PlayType Play { get; set; }
-    }
-    public enum PlayType
-    {
-        GameStart = 0,
-        GameEnd = 1,
-        PeriodStart = 2,
-        PeriodEnd = 3,
-        JumpBallWon = 4,
-        JumpBallLost = 5,
-        Shot2Made = 6,
-        Shot2Missed = 7,
-        Shot3Made = 8,
-        Shot3Missed = 9,
-        FreeThrowMade = 10,
-        FreeThrowMissed = 11,
-        OffensiveRebound = 12,
-        DeffensiveRebound = 13,
-        TeamRebound = 14,
-        Assist = 15,
-        Turnover = 16,
-        Steal = 17,
-        Block = 18,
-        Foul = 19,
-        FoulDrawn = 20,
-        UnsportsmanlikeFoul = 21,
-        OffensiveFoul = 22,
-        Ejection = 23,
-        Timeout = 24,
-        SubstitutionIn = 25,
-        SubstitutionOut = 26,
-        Dunk = 27,
-        Putback = 28,
-        Unknown = 29
-    }
+    public int Id { get; set; }
+    public int OrderNumber { get; set; }
+    public string Clock { get; set; } = string.Empty;
+    public Period Period { get; set; }
+    public TeamSelect Team { get; set; }
+    public int Player { get; set; }
+    public PlayType PlayType { get; set; }
+    public List<string> Flags { get; set; } = new();
+    public List<string> SubFlags { get; set; } = new();
+    public Point Point { get; set; } = new();
+    public bool PossessionSwitch { get; set; }
+    public bool ArrowSwitch { get; set; }
+    public bool ScoreChange { get; set; }
+    public StatsSnapshot TeamA { get; set; } = new();
+    public StatsSnapshot TeamB { get; set; } = new();
+    public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Identifies which team performed the action.
+/// </summary>
+public enum TeamSelect
+{
+    TeamA,
+    TeamB
+}
+
+/// <summary>
+/// Enumerates the different periods in a game.
+/// </summary>
+public enum Period
+{
+    Q1 = 1,
+    Q2 = 2,
+    Q3 = 3,
+    Q4 = 4,
+    OT1 = 5,
+    OT2 = 6
+}
+
+/// <summary>
+/// Type of play that occurred.
+/// </summary>
+public enum PlayType
+{
+    FieldGoal,
+    FreeThrow,
+    Rebound,
+    Turnover,
+    Foul,
+    Substitution,
+    Timeout,
+    JumpBall,
+    Violation,
+    Other
+}
+
+/// <summary>
+/// Simple point wrapper used in the feed.
+/// </summary>
+public class Point
+{
+    public int Value { get; set; }
 }

--- a/StatsBB/Model/PlayerInfo.cs
+++ b/StatsBB/Model/PlayerInfo.cs
@@ -1,0 +1,11 @@
+namespace StatsBB.Model;
+
+/// <summary>
+/// Basic information about a player used for lookups when mapping plays.
+/// </summary>
+public class PlayerInfo
+{
+    public int Id { get; set; }
+    public int Number { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/StatsBB/Model/StatsSnapshot.cs
+++ b/StatsBB/Model/StatsSnapshot.cs
@@ -1,0 +1,17 @@
+namespace StatsBB.Model;
+
+/// <summary>
+/// Represents a snapshot of team statistics after a play.
+/// Only a few fields are included for demo purposes.
+/// </summary>
+public class StatsSnapshot
+{
+    /// <summary>Team score after the play.</summary>
+    public int Score { get; set; }
+
+    /// <summary>Total number of fouls committed.</summary>
+    public int Fouls { get; set; }
+
+    /// <summary>Remaining timeouts.</summary>
+    public int TimeoutsLeft { get; set; }
+}

--- a/StatsBB/ViewModel/PlayByPlayViewModel.cs
+++ b/StatsBB/ViewModel/PlayByPlayViewModel.cs
@@ -1,0 +1,109 @@
+using StatsBB.Model;
+
+namespace StatsBB.ViewModel;
+
+/// <summary>
+/// View model used to render play-by-play information in the UI.
+/// </summary>
+public class PlayByPlayViewModel
+{
+    public int Id { get; set; }
+    public int Sequence { get; set; }
+    public string Time { get; set; } = string.Empty;
+    public string PeriodLabel { get; set; } = string.Empty;
+    public string TeamName { get; set; } = string.Empty;
+    public int? PlayerNumber { get; set; }
+    public string? PlayerName { get; set; }
+    public string ActionDescription { get; set; } = string.Empty;
+    public bool IsMadeShot { get; set; }
+    public bool IsFreeThrow { get; set; }
+    public bool IsRebound { get; set; }
+    public bool IsTurnover { get; set; }
+    public bool PossessionChange { get; set; }
+    public bool ArrowSwitch { get; set; }
+    public bool IsScoreChange { get; set; }
+    public int Points { get; set; }
+    public string ScoreAfter { get; set; } = string.Empty;
+    public StatsSnapshot TeamAStats { get; set; } = new();
+    public StatsSnapshot TeamBStats { get; set; } = new();
+
+    /// <summary>
+    /// Maps a raw <see cref="PlayByPlay"/> into a view model instance.
+    /// </summary>
+    public static PlayByPlayViewModel Map(
+        PlayByPlay play,
+        IDictionary<int, PlayerInfo> players,
+        StatsSnapshot[]? scoreData = null)
+    {
+        var vm = new PlayByPlayViewModel
+        {
+            Id = play.Id,
+            Sequence = play.OrderNumber,
+            Time = play.Clock,
+            PeriodLabel = play.Period.ToLabel(),
+            TeamName = play.Team == TeamSelect.TeamA ? "Team A" : "Team B",
+            PossessionChange = play.PossessionSwitch,
+            ArrowSwitch = play.ArrowSwitch,
+            IsScoreChange = play.ScoreChange,
+            Points = play.Point.Value,
+            ScoreAfter = $"{play.TeamA.Score}\u2013{play.TeamB.Score}",
+            TeamAStats = play.TeamA,
+            TeamBStats = play.TeamB
+        };
+
+        if (players != null && players.TryGetValue(play.Player, out var info))
+        {
+            vm.PlayerNumber = info.Number;
+            vm.PlayerName = info.Name;
+        }
+
+        vm.IsFreeThrow = play.PlayType == PlayType.FreeThrow;
+        vm.IsMadeShot =
+            (play.PlayType == PlayType.FieldGoal || vm.IsFreeThrow) &&
+            play.Flags.Contains("made");
+        vm.IsRebound = play.PlayType == PlayType.Rebound;
+        vm.IsTurnover = play.PlayType == PlayType.Turnover;
+
+        vm.ActionDescription = string.IsNullOrWhiteSpace(play.Description)
+            ? BuildDescription(play, vm.PlayerName, vm.PlayerNumber)
+            : play.Description;
+
+        return vm;
+    }
+
+    private static string BuildDescription(PlayByPlay play, string? name, int? number)
+    {
+        var prefix = name != null && number.HasValue ? $"{name} ({number}) " : string.Empty;
+        return prefix + play.PlayType switch
+        {
+            PlayType.FieldGoal when play.Flags.Contains("made") && play.Flags.Contains("3pt")
+                => "makes 3-pt shot",
+            PlayType.FieldGoal when play.Flags.Contains("made") => "makes shot",
+            PlayType.FieldGoal when play.Flags.Contains("missed") => "misses shot",
+            PlayType.FreeThrow when play.Flags.Contains("made") => "makes free throw",
+            PlayType.FreeThrow when play.Flags.Contains("missed") => "misses free throw",
+            PlayType.Rebound => (play.Flags.Contains("offensive") ? "offensive" : "defensive") + " rebound",
+            PlayType.Turnover => "turnover",
+            PlayType.Foul => "foul",
+            PlayType.Substitution => "substitution",
+            _ => play.Description
+        };
+    }
+}
+
+internal static class PeriodExtensions
+{
+    public static string ToLabel(this Period period)
+    {
+        return period switch
+        {
+            Period.Q1 => "Q1",
+            Period.Q2 => "Q2",
+            Period.Q3 => "Q3",
+            Period.Q4 => "Q4",
+            Period.OT1 => "OT",
+            Period.OT2 => "OT2",
+            _ => period.ToString()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- create detailed `PlayByPlay` model and helper types
- implement `PlayByPlayViewModel` with mapping logic
- add xUnit test project covering mapping cases

## Testing
- `dotnet test StatsBB.Tests/StatsBB.Tests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c48f2ae548326880cb2f1ec6f76d2