### PR TITLE
Add stats tab view and model

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1559,9 +1559,7 @@ Grid.Column="4" />
     </Grid>
         </TabItem>
         <TabItem Header="STATS">
-            <TextBlock Text="Stats go here." 
-                       VerticalAlignment="Center" 
-                       HorizontalAlignment="Center"/>
+            <controls:StatsView DataContext="{Binding StatsVM}" />
         </TabItem>
     </TabControl>
 </Window>

--- a/StatsBB/Model/PlayerStats.cs
+++ b/StatsBB/Model/PlayerStats.cs
@@ -1,0 +1,33 @@
+using StatsBB.Model;
+
+namespace StatsBB.Model;
+
+public class PlayerStats
+{
+    public int No { get; set; }
+    public string Player { get; set; } = string.Empty;
+    public bool S5 { get; set; }
+    public bool OnCourt { get; set; }
+    public string Mins { get; set; } = "0";
+    public int Pts { get; set; }
+    public string FG { get; set; } = "0/0";
+    public double FGPercent { get; set; }
+    public string TwoP { get; set; } = "0/0";
+    public double TwoPPercent { get; set; }
+    public string ThreeP { get; set; } = "0/0";
+    public double ThreePPercent { get; set; }
+    public string FT { get; set; } = "0/0";
+    public double FTPercent { get; set; }
+    public int OFF { get; set; }
+    public int DEF { get; set; }
+    public int REB { get; set; }
+    public int AST { get; set; }
+    public int TO { get; set; }
+    public int STL { get; set; }
+    public int BLK { get; set; }
+    public int BLKR { get; set; }
+    public int PF { get; set; }
+    public int FoulsOn { get; set; }
+    public int PlusMinus { get; set; }
+    public int Index { get; set; }
+}

--- a/StatsBB/UserControls/StatsView.xaml
+++ b/StatsBB/UserControls/StatsView.xaml
@@ -1,0 +1,73 @@
+<UserControl x:Class="StatsBB.UserControls.StatsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <DataGrid Grid.Column="0" ItemsSource="{Binding TeamAStats}" AutoGenerateColumns="False" HeadersVisibility="Column">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="No." Binding="{Binding No}" Width="40"/>
+                <DataGridTextColumn Header="Player" Binding="{Binding Player}" Width="120"/>
+                <DataGridCheckBoxColumn Header="s5" Binding="{Binding S5}" Width="40"/>
+                <DataGridCheckBoxColumn Header="onCourt" Binding="{Binding OnCourt}" Width="60"/>
+                <DataGridTextColumn Header="Mins" Binding="{Binding Mins}" Width="50"/>
+                <DataGridTextColumn Header="Pts" Binding="{Binding Pts}" Width="40"/>
+                <DataGridTextColumn Header="FG" Binding="{Binding FG}" Width="60"/>
+                <DataGridTextColumn Header="FG%" Binding="{Binding FGPercent}" Width="50"/>
+                <DataGridTextColumn Header="2P" Binding="{Binding TwoP}" Width="60"/>
+                <DataGridTextColumn Header="2P%" Binding="{Binding TwoPPercent}" Width="50"/>
+                <DataGridTextColumn Header="3P" Binding="{Binding ThreeP}" Width="60"/>
+                <DataGridTextColumn Header="3P%" Binding="{Binding ThreePPercent}" Width="50"/>
+                <DataGridTextColumn Header="FT" Binding="{Binding FT}" Width="60"/>
+                <DataGridTextColumn Header="FT%" Binding="{Binding FTPercent}" Width="50"/>
+                <DataGridTextColumn Header="OFF" Binding="{Binding OFF}" Width="40"/>
+                <DataGridTextColumn Header="DEF" Binding="{Binding DEF}" Width="40"/>
+                <DataGridTextColumn Header="REB" Binding="{Binding REB}" Width="40"/>
+                <DataGridTextColumn Header="AST" Binding="{Binding AST}" Width="40"/>
+                <DataGridTextColumn Header="TO" Binding="{Binding TO}" Width="40"/>
+                <DataGridTextColumn Header="STL" Binding="{Binding STL}" Width="40"/>
+                <DataGridTextColumn Header="BLK" Binding="{Binding BLK}" Width="40"/>
+                <DataGridTextColumn Header="BLKR" Binding="{Binding BLKR}" Width="50"/>
+                <DataGridTextColumn Header="PF" Binding="{Binding PF}" Width="40"/>
+                <DataGridTextColumn Header="Fls on" Binding="{Binding FoulsOn}" Width="50"/>
+                <DataGridTextColumn Header="+/-" Binding="{Binding PlusMinus}" Width="50"/>
+                <DataGridTextColumn Header="Index" Binding="{Binding Index}" Width="50"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <DataGrid Grid.Column="1" ItemsSource="{Binding TeamBStats}" AutoGenerateColumns="False" HeadersVisibility="Column">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="No." Binding="{Binding No}" Width="40"/>
+                <DataGridTextColumn Header="Player" Binding="{Binding Player}" Width="120"/>
+                <DataGridCheckBoxColumn Header="s5" Binding="{Binding S5}" Width="40"/>
+                <DataGridCheckBoxColumn Header="onCourt" Binding="{Binding OnCourt}" Width="60"/>
+                <DataGridTextColumn Header="Mins" Binding="{Binding Mins}" Width="50"/>
+                <DataGridTextColumn Header="Pts" Binding="{Binding Pts}" Width="40"/>
+                <DataGridTextColumn Header="FG" Binding="{Binding FG}" Width="60"/>
+                <DataGridTextColumn Header="FG%" Binding="{Binding FGPercent}" Width="50"/>
+                <DataGridTextColumn Header="2P" Binding="{Binding TwoP}" Width="60"/>
+                <DataGridTextColumn Header="2P%" Binding="{Binding TwoPPercent}" Width="50"/>
+                <DataGridTextColumn Header="3P" Binding="{Binding ThreeP}" Width="60"/>
+                <DataGridTextColumn Header="3P%" Binding="{Binding ThreePPercent}" Width="50"/>
+                <DataGridTextColumn Header="FT" Binding="{Binding FT}" Width="60"/>
+                <DataGridTextColumn Header="FT%" Binding="{Binding FTPercent}" Width="50"/>
+                <DataGridTextColumn Header="OFF" Binding="{Binding OFF}" Width="40"/>
+                <DataGridTextColumn Header="DEF" Binding="{Binding DEF}" Width="40"/>
+                <DataGridTextColumn Header="REB" Binding="{Binding REB}" Width="40"/>
+                <DataGridTextColumn Header="AST" Binding="{Binding AST}" Width="40"/>
+                <DataGridTextColumn Header="TO" Binding="{Binding TO}" Width="40"/>
+                <DataGridTextColumn Header="STL" Binding="{Binding STL}" Width="40"/>
+                <DataGridTextColumn Header="BLK" Binding="{Binding BLK}" Width="40"/>
+                <DataGridTextColumn Header="BLKR" Binding="{Binding BLKR}" Width="50"/>
+                <DataGridTextColumn Header="PF" Binding="{Binding PF}" Width="40"/>
+                <DataGridTextColumn Header="Fls on" Binding="{Binding FoulsOn}" Width="50"/>
+                <DataGridTextColumn Header="+/-" Binding="{Binding PlusMinus}" Width="50"/>
+                <DataGridTextColumn Header="Index" Binding="{Binding Index}" Width="50"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/StatsBB/UserControls/StatsView.xaml.cs
+++ b/StatsBB/UserControls/StatsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace StatsBB.UserControls;
+
+public partial class StatsView : UserControl
+{
+    public StatsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -50,6 +50,8 @@ public class MainWindowViewModel : ViewModelBase
     public ObservableCollection<PlayerPositionViewModel> EligibleFreeThrowCourtPlayers { get; } = new();
     public ObservableCollection<PlayerPositionViewModel> EligibleFreeThrowBenchPlayers { get; } = new();
 
+    public StatsTabViewModel StatsVM { get; }
+
     public ObservableCollection<Player> TeamACourtPlayers =>
         new(Players.Where(p => p.IsTeamA && p.IsActive));
     public ObservableCollection<Player> TeamBCourtPlayers =>
@@ -276,6 +278,7 @@ public class MainWindowViewModel : ViewModelBase
 
         PlayerLayoutService.PopulateTeams(Players);
         RegenerateTeams();
+        StatsVM = new StatsTabViewModel(Players);
     }
     private void BeginSubstitution()
     {

--- a/StatsBB/ViewModel/StatsTabViewModel.cs
+++ b/StatsBB/ViewModel/StatsTabViewModel.cs
@@ -1,0 +1,29 @@
+using System.Collections.ObjectModel;
+using StatsBB.Model;
+using StatsBB.MVVM;
+
+namespace StatsBB.ViewModel;
+
+public class StatsTabViewModel : ViewModelBase
+{
+    public ObservableCollection<PlayerStats> TeamAStats { get; } = new();
+    public ObservableCollection<PlayerStats> TeamBStats { get; } = new();
+
+    public StatsTabViewModel(ObservableCollection<Player> players)
+    {
+        foreach (var p in players)
+        {
+            var ps = new PlayerStats
+            {
+                No = p.Number,
+                Player = p.Name,
+                S5 = p.IsActive,
+                OnCourt = p.IsActive
+            };
+            if (p.IsTeamA)
+                TeamAStats.Add(ps);
+            else
+                TeamBStats.Add(ps);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `PlayerStats` data model
- add `StatsTabViewModel` to expose stats collections
- add `StatsView` user control with two `DataGrid`s for both teams
- expose `StatsVM` from `MainWindowViewModel` and hook to Stats tab

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c48051a0c8326a45e9361a7905497