### PR TITLE
Add game/statline models and color converter

### DIFF
--- a/StatsBB/Converters/TeamColorToForegroundConverter.cs
+++ b/StatsBB/Converters/TeamColorToForegroundConverter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using StatsBB.Model;
+
+namespace StatsBB.Converters
+{
+    public class TeamColorToForegroundConverter : IValueConverter
+    {
+        private static readonly Dictionary<TeamColor, Brush> BrushMap = new()
+        {
+            { TeamColor.Yellow, Brushes.Black },
+            { TeamColor.Orange, Brushes.Black },
+            { TeamColor.Blue, Brushes.White },
+            { TeamColor.LightBlue, Brushes.Black },
+            { TeamColor.DarkBlue, Brushes.White },
+            { TeamColor.Grey, Brushes.Black },
+            { TeamColor.Black, Brushes.White },
+            { TeamColor.Purple, Brushes.White },
+            { TeamColor.Pink, Brushes.Black },
+            { TeamColor.Red, Brushes.Black },
+            { TeamColor.Green, Brushes.White },
+            { TeamColor.White, Brushes.Black },
+            { TeamColor.Teal, Brushes.White },
+            { TeamColor.Lime, Brushes.Black },
+            { TeamColor.Brown, Brushes.White },
+            { TeamColor.Maroon, Brushes.White },
+            { TeamColor.BlueGrey, Brushes.Black },
+            { TeamColor.Mustard, Brushes.Black }
+        };
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is TeamColor color && BrushMap.TryGetValue(color, out var brush))
+                return brush;
+            return Brushes.Black;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/StatsBB/Model/Game.cs
+++ b/StatsBB/Model/Game.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace StatsBB.Model
+{
+    public class Game
+    {
+        public Team TeamA { get; set; } = new();
+        public Team TeamB { get; set; } = new();
+        public int Period { get; set; }
+        public int PeriodLength { get; set; }
+        public bool Overtime { get; set; }
+        public string Q1Score { get; set; } = string.Empty;
+        public string Q2Score { get; set; } = string.Empty;
+        public string Q3Score { get; set; } = string.Empty;
+        public string Q4Score { get; set; } = string.Empty;
+        public string QT1Score { get; set; } = string.Empty;
+        public string OT2Score { get; set; } = string.Empty;
+        public string OT3Score { get; set; } = string.Empty;
+        public string OT4Score { get; set; } = string.Empty;
+        public string OT5Score { get; set; } = string.Empty;
+        public string OT6Score { get; set; } = string.Empty;
+        public string OT7Score { get; set; } = string.Empty;
+        public string OT8Score { get; set; } = string.Empty;
+        public int Periods { get; set; } = 4;
+        public int PeriodTime { get; set; } = 10;
+        public int MaxPlayerFoul { get; set; } = 5;
+        public int TeamFoulLimit { get; set; } = 4;
+        public bool OT { get; set; } = true;
+        public int OTTime { get; set; } = 5;
+        public bool JumpBall { get; set; } = false;
+        public int MaxTechnicalFouls { get; set; } = 2;
+        public int PlayersOnCourt { get; set; } = 5;
+        public bool TimeoutsPerPeriod { get; set; } = false;
+        public List<int> TimeoutsPerPeriodList { get; set; } = new();
+        public bool TimeoutsPerHalf { get; set; } = true;
+        public int TieoutsFirstHalf { get; set; } = 2;
+        public int TieoutsSecondHalf { get; set; } = 3;
+        public int TimeoutsPerOvertime { get; set; } = 0;
+        public List<PlayByPlay> PlayByPlay { get; set; } = new();
+    }
+}

--- a/StatsBB/Model/Period.cs
+++ b/StatsBB/Model/Period.cs
@@ -1,0 +1,18 @@
+namespace StatsBB.Model
+{
+    public enum Period
+    {
+        Q1 = 1,
+        Q2 = 2,
+        Q3 = 3,
+        Q4 = 4,
+        OT1 = 5,
+        OT2 = 6,
+        OT3 = 7,
+        OT4 = 8,
+        OT5 = 9,
+        OT6 = 10,
+        OT7 = 11,
+        OT8 = 12
+    }
+}

--- a/StatsBB/Model/PlayByPlay.cs
+++ b/StatsBB/Model/PlayByPlay.cs
@@ -1,17 +1,28 @@
-﻿namespace StatsBB.Model
+using System.Collections.Generic;
+using System.Windows;
+
+namespace StatsBB.Model
 {
     public class PlayByPlay
     {
         public int Id { get; set; }
-        public int Period { get; set; }
-        public string Time { get; set; }
-        public bool TeamA {  get; set; }
-        public int PlayerNumer { get; set; }
-        public string PlayerName { get; set; }
-        public bool IsTeamAction { get; set; }
-        public bool IsGameAction { get; set; }
-        public PlayType Play { get; set; }
+        public int OrderNumber { get; set; }
+        public string Clock { get; set; } = string.Empty;
+        public Period Period { get; set; }
+        public TeamSelect Team { get; set; }
+        public int Player { get; set; }
+        public PlayType PlayType { get; set; }
+        public List<string> Flags { get; set; } = new();
+        public List<string> Subflags { get; set; } = new();
+        public Point? Point { get; set; }
+        public bool PossesionSwitch { get; set; }
+        public bool ArrowSwitch { get; set; }
+        public bool ScoreChange { get; set; }
+        public List<string> TeamA { get; set; } = new();
+        public List<string> TeamB { get; set; } = new();
+        public string Description { get; set; } = string.Empty;
     }
+
     public enum PlayType
     {
         GameStart = 0,

--- a/StatsBB/Model/PlayerStatLine.cs
+++ b/StatsBB/Model/PlayerStatLine.cs
@@ -1,0 +1,8 @@
+namespace StatsBB.Model
+{
+    public class PlayerStatLine : StatLine
+    {
+        public bool OnCourt { get; set; }
+        public bool S5 { get; set; }
+    }
+}

--- a/StatsBB/Model/StatLine.cs
+++ b/StatsBB/Model/StatLine.cs
@@ -1,0 +1,28 @@
+namespace StatsBB.Model
+{
+    public class StatLine
+    {
+        public int Points { get; set; }
+        public int Block { get; set; }
+        public int BlockR { get; set; }
+        public int ReboundD { get; set; }
+        public int ReboundO { get; set; }
+        public int PersonalFouls { get; set; }
+        public int FoulsDrawn { get; set; }
+        public int FieldGoal2Attemt { get; set; }
+        public int FieldGoal2Made { get; set; }
+        public float FieldGoal2Percentage { get; set; }
+        public int FieldGoal3Attempt { get; set; }
+        public int FieldGoal3Made { get; set; }
+        public float FieldGoal3Percentage { get; set; }
+        public int FieldGoalAttempt { get; set; }
+        public int FieldGoalMade { get; set; }
+        public float FieldGoalMadePercentage { get; set; }
+        public int FreeThrowAttempt { get; set; }
+        public int FreeThrowMade { get; set; }
+        public float FreeThrowPercentage { get; set; }
+        public int TimeOnField { get; set; }
+        public int PlusMinus { get; set; }
+        public int Efficiency { get; set; }
+    }
+}

--- a/StatsBB/Model/Team.cs
+++ b/StatsBB/Model/Team.cs
@@ -1,0 +1,10 @@
+namespace StatsBB.Model
+{
+    public class Team
+    {
+        public string TeamName { get; set; } = string.Empty;
+        public string TeamShortName { get; set; } = string.Empty;
+        public TeamColor TeamColor { get; set; }
+        public TeamStats Stats { get; set; } = new();
+    }
+}

--- a/StatsBB/Model/TeamColor.cs
+++ b/StatsBB/Model/TeamColor.cs
@@ -1,0 +1,24 @@
+namespace StatsBB.Model
+{
+    public enum TeamColor
+    {
+        Yellow,
+        Orange,
+        Blue,
+        LightBlue,
+        DarkBlue,
+        Grey,
+        Black,
+        Purple,
+        Pink,
+        Red,
+        Green,
+        White,
+        Teal,
+        Lime,
+        Brown,
+        Maroon,
+        BlueGrey,
+        Mustard
+    }
+}

--- a/StatsBB/Model/TeamSelect.cs
+++ b/StatsBB/Model/TeamSelect.cs
@@ -1,0 +1,9 @@
+namespace StatsBB.Model
+{
+    public enum TeamSelect
+    {
+        None = 0,
+        TeamA = 1,
+        TeamB = 2
+    }
+}

--- a/StatsBB/Model/TeamStatline.cs
+++ b/StatsBB/Model/TeamStatline.cs
@@ -1,0 +1,11 @@
+namespace StatsBB.Model
+{
+    public class TeamStatline : StatLine
+    {
+        public int TeamReboundsO { get; set; }
+        public int TeamReboundsD { get; set; }
+        public int TeamReboundsTotal { get; set; }
+        public int TeamFouls { get; set; }
+        public int TeamTurovers { get; set; }
+    }
+}

--- a/StatsBB/Model/TeamStats.cs
+++ b/StatsBB/Model/TeamStats.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace StatsBB.Model
+{
+    public class TeamStats
+    {
+        public List<PlayerStatLine> Players { get; set; } = new();
+        public TeamStatline Team { get; set; } = new();
+    }
+}

--- a/StatsBB/ViewModel/GameViewModel.cs
+++ b/StatsBB/ViewModel/GameViewModel.cs
@@ -1,0 +1,11 @@
+using StatsBB.Model;
+
+namespace StatsBB.ViewModel
+{
+    public class GameViewModel
+    {
+        public Game CurrentGame { get; set; } = new();
+        public Period CurrentPeriod { get; set; }
+        public int CurrentPeriodTime { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement StatLine with derived PlayerStatLine and TeamStatline
- create TeamStats, Team and Game models
- add supporting enums (TeamColor, TeamSelect, Period)
- expand PlayByPlay with additional fields
- add GameViewModel
- provide TeamColorToForegroundConverter for ideal text color

## Testing
- `dotnet build StatsBB/StatsBB.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c476fe850832697b3abc3e34f42ca