### PR TITLE
Refactor GameClock to MVVM

### DIFF
--- a/StatsBB/UserControls/GameClock.xaml
+++ b/StatsBB/UserControls/GameClock.xaml
@@ -1,13 +1,17 @@
 <UserControl x:Class="StatsBB.UserControls.GameClock"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:StatsBB.ViewModel">
+    <UserControl.DataContext>
+        <vm:GameClockViewModel />
+    </UserControl.DataContext>
     <Border CornerRadius="8" BorderBrush="#888" BorderThickness="2" Background="White" Width="300">
         <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <TextBlock x:Name="PeriodText" Grid.Row="0" Text="Q1 - In Progress" Foreground="Black" FontWeight="Bold" FontSize="16" HorizontalAlignment="Center" Margin="5" />
+            <TextBlock Grid.Row="0" Text="{Binding Period}" Foreground="Black" FontWeight="Bold" FontSize="16" HorizontalAlignment="Center" Margin="5" />
             <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -20,13 +24,22 @@
                     <Button Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" />
                 </StackPanel>
                 <Border Grid.Column="1" Padding="0" Margin="0,0">
-                    <TextBlock x:Name="TimeText" Text="10:00" Foreground="black" FontSize="36" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding Time}" Foreground="black" FontSize="36" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Border>
                 <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Button Content="▲" Width="25" Height="25" Background="White" BorderThickness="0" />
                     <Button Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" />
                 </StackPanel>
-                <Button x:Name="StartStopButton" Grid.Column="3" Content="STOP" Width="70" Height="50" Background="Green" Foreground="White" FontWeight="Bold" VerticalAlignment="Center" Margin="10,0,0,0" Click="StartStop_Click"/>
+                <Button Grid.Column="3"
+                        Content="{Binding StartStopText}"
+                        Background="{Binding StartStopBrush}"
+                        Foreground="White"
+                        Width="70"
+                        Height="50"
+                        FontWeight="Bold"
+                        VerticalAlignment="Center"
+                        Margin="10,0,0,0"
+                        Command="{Binding ToggleCommand}" />
             </Grid>
         </Grid>
     </Border>

--- a/StatsBB/UserControls/GameClock.xaml.cs
+++ b/StatsBB/UserControls/GameClock.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
-using StatsBB.Services;
+using StatsBB.ViewModel;
 
 namespace StatsBB.UserControls;
 
@@ -10,23 +9,6 @@ public partial class GameClock : UserControl
     public GameClock()
     {
         InitializeComponent();
-        GameClockService.TimeUpdated += UpdateDisplay;
-        UpdateDisplay();
+        DataContext = new GameClockViewModel();
     }
-
-    private void StartStop_Click(object sender, RoutedEventArgs e)
-    {
-        GameClockService.Toggle();
-        UpdateDisplay();
-    }
-
-    private void UpdateDisplay()
-    {
-        TimeText.Text = GameClockService.TimeLeftString;
-        PeriodText.Text = GameClockService.Period;
-        StartStopButton.Content = GameClockService.IsRunning ? "STOP" : "START";
-        StartStopButton.Background = GameClockService.IsRunning ? Brushes.Green : Brushes.Red;
-    }
-
-    public void Toggle() => StartStop_Click(this, new RoutedEventArgs());
 }

--- a/StatsBB/ViewModel/GameClockViewModel.cs
+++ b/StatsBB/ViewModel/GameClockViewModel.cs
@@ -1,0 +1,36 @@
+using System.Windows.Input;
+using System.Windows.Media;
+using StatsBB.MVVM;
+using StatsBB.Services;
+
+namespace StatsBB.ViewModel;
+
+public class GameClockViewModel : ViewModelBase
+{
+    public GameClockViewModel()
+    {
+        ToggleCommand = new RelayCommand(_ => Toggle());
+        GameClockService.TimeUpdated += OnTimeUpdated;
+    }
+
+    public string Time => GameClockService.TimeLeftString;
+    public string Period => GameClockService.Period;
+
+    public string StartStopText => GameClockService.IsRunning ? "STOP" : "START";
+    public Brush StartStopBrush => GameClockService.IsRunning ? Brushes.Green : Brushes.Red;
+
+    public ICommand ToggleCommand { get; }
+
+    private void Toggle()
+    {
+        GameClockService.Toggle();
+        OnPropertyChanged(nameof(StartStopText));
+        OnPropertyChanged(nameof(StartStopBrush));
+    }
+
+    private void OnTimeUpdated()
+    {
+        OnPropertyChanged(nameof(Time));
+        OnPropertyChanged(nameof(Period));
+    }
+}


### PR DESCRIPTION
## Summary
- create `GameClockViewModel` to manage clock state
- bind `GameClock` UI to view model
- remove code-behind logic in `GameClock` control

## Testing
- `dotnet build StatsBB/StatsBB.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee2c6dd908326b0457bbb03322ad6