### PR TITLE
Fix team name bindings in stats view

### DIFF
--- a/StatsBB/UserControls/StatsView.xaml
+++ b/StatsBB/UserControls/StatsView.xaml
@@ -10,15 +10,15 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Text="{Binding Game.HomeTeam.TeamName}" Grid.Column="0" HorizontalAlignment="Left" Margin="10 10 10 10" FontWeight="Bold" FontSize="60"/>
+            <TextBlock Text="{Binding HomeTeamName}" Grid.Column="0" HorizontalAlignment="Left" Margin="10 10 10 10" FontWeight="Bold" FontSize="60"/>
             <TextBlock Text="{Binding HomeScore}" Grid.Column="1" HorizontalAlignment="Center" Margin="10" FontWeight="Bold" FontSize="60"/>
             <TextBlock Text=":" Grid.Column="2" FontWeight="Bold" FontSize="60" Margin="10"/>
             <TextBlock Text="{Binding AwayScore}" Grid.Column="3" HorizontalAlignment="Center" Margin="10" FontWeight="Bold" FontSize="60" />
-            <TextBlock Text="{Binding Game.AwayTeam.TeamName}" Grid.Column="4" HorizontalAlignment="Right" Margin="10" FontWeight="Bold" FontSize="60"/>
+            <TextBlock Text="{Binding AwayTeamName}" Grid.Column="4" HorizontalAlignment="Right" Margin="10" FontWeight="Bold" FontSize="60"/>
         </Grid>
         <StackPanel Width="1070">
         <Separator Margin="10"/>
-            <TextBlock Text="{Binding Game.HomeTeam.TeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
+            <TextBlock Text="{Binding HomeTeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
             
         <DataGrid ItemsSource="{Binding HomePlayers}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False" IsReadOnly="True" Width="1050">
             <DataGrid.Columns>
@@ -63,7 +63,7 @@
 
         <Separator Margin="10"/>
 
-        <TextBlock Text="{Binding Game.AwayTeam.TeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
+        <TextBlock Text="{Binding AwayTeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
         <DataGrid ItemsSource="{Binding AwayPlayers}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False" IsReadOnly="True"  Width="1050">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="*"/>

--- a/StatsBB/ViewModel/StatsTabViewModel.cs
+++ b/StatsBB/ViewModel/StatsTabViewModel.cs
@@ -15,6 +15,9 @@ public class StatsTabViewModel : ViewModelBase
         Game = game;
     }
 
+    public string HomeTeamName => Game.HomeTeam?.TeamName ?? string.Empty;
+    public string AwayTeamName => Game.AwayTeam?.TeamName ?? string.Empty;
+
     public ObservableCollection<Player> HomePlayers =>
         new(Game.HomeTeam?.Players
                 .Where(p => p.IsPlaying)
@@ -83,6 +86,8 @@ public class StatsTabViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(HomePlayers));
         OnPropertyChanged(nameof(AwayPlayers));
+        OnPropertyChanged(nameof(HomeTeamName));
+        OnPropertyChanged(nameof(AwayTeamName));
         OnPropertyChanged(nameof(HomeScore));
         OnPropertyChanged(nameof(AwayScore));
         OnPropertyChanged(nameof(HomeP1));


### PR DESCRIPTION
## Summary
- expose team names via new properties in `StatsTabViewModel`
- bind to these properties from `StatsView`
- refresh team names when stats are refreshed

## Testing
- `dotnet` not installed, so no build/test run

------
https://chatgpt.com/codex/tasks/task_e_68701963287c8326ab14bacd83cb718b