### PR TITLE
Add starting five selection panel and stats highlight

### DIFF
--- a/StatsBB/Converters/BoolToXConverter.cs
+++ b/StatsBB/Converters/BoolToXConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace StatsBB.Converters;
+
+public class BoolToXConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b && b)
+            return "x";
+        return string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string s)
+            return s.Equals("x", StringComparison.InvariantCultureIgnoreCase);
+        return false;
+    }
+}

--- a/StatsBB/Domain/Player.cs
+++ b/StatsBB/Domain/Player.cs
@@ -11,6 +11,22 @@ public class Player : INotifyPropertyChanged
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public bool IsActive { get; set; }
+    private bool _s5;
+    /// <summary>
+    /// Indicates whether the player belongs to the starting five.
+    /// </summary>
+    public bool S5
+    {
+        get => _s5;
+        set
+        {
+            if (_s5 != value)
+            {
+                _s5 = value;
+                OnPropertyChanged();
+            }
+        }
+    }
     /// <summary>
     /// Indicates whether the player is on the game roster. Only players with
     /// <c>IsPlaying</c> set to <c>true</c> should appear on the main view and in

--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1259,6 +1259,107 @@ Margin="4" />
                                 </StackPanel>
                             </StackPanel>
                         </Grid>
+                        <!-- Starting Five Panel -->
+                        <Grid Visibility="{Binding StartingFivePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="Auto">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="160"/>
+                                        <ColumnDefinition Width="100"/>
+                                        <ColumnDefinition Width="80"/>
+                                        <ColumnDefinition Width="100"/>
+                                        <ColumnDefinition Width="160"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="30" />
+                                        <RowDefinition Height="400" />
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="BENCH" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="S5" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="S5" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="4" Text="BENCH" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+
+                                    <Border Grid.Row="1" Grid.Column="0" Background="#ccd3d3d3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamAStartingBenchPlayers}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" FlowDirection="RightToLeft" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtAPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleStartingFiveCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+                                    <Border Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamAStartingFivePlayers}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" FlowDirection="RightToLeft" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtAPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleStartingFiveCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+
+                                    <WrapPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <Button Content="OK" Width="60" Height="60" FontSize="16" FontWeight="Bold" Background="DarkGreen" Foreground="White" Command="{Binding ConfirmStartingFiveCommand}" IsEnabled="{Binding IsStartingFiveConfirmEnabled}"/>
+                                    </WrapPanel>
+
+                                    <Border Grid.Row="1" Grid.Column="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2" Background="#cceeeeee">
+                                        <ItemsControl ItemsSource="{Binding TeamBStartingFivePlayers}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtBPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleStartingFiveCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+
+                                    <Border Grid.Row="1" Grid.Column="4" Background="#ccd3d3d3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamBStartingBenchPlayers}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtBPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleStartingFiveCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
                         <!-- Substitution Panel -->
                         <Grid Visibility="{Binding SubstitutionPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
                             <StackPanel HorizontalAlignment="Center"
@@ -1497,6 +1598,7 @@ Margin="4" />
                         <Button Content="TURNOVER (R)" Style="{StaticResource Turnover}" Command="{Binding StartTurnoverCommand}"/>
                         <Button Content="TIME OUT" Style="{StaticResource TimeOut}" Command="{Binding StartTimeoutCommand}"/>
                         <Button Content="JUMP BALL" Style="{StaticResource JumpBall}" IsEnabled="False"/>
+                        <Button Content="S5" Style="{StaticResource Sub}" Command="{Binding StartStartingFiveCommand}"/>
                             <Button Content="SUBSTITUTIONS" Style="{StaticResource Sub}" Command="{Binding StartSubstitutionCommand}" IsEnabled="False"/>
                             <Button Content="FREE THROWS" Style="{StaticResource FreeThrows}" Command="{Binding StartFreeThrowsCommand}" IsEnabled="False"/>
                             <Button Content="ASSIST" Style="{StaticResource Assist}" Command="{Binding StartAssistCommand}" IsEnabled="False"/>

--- a/StatsBB/UserControls/StatsView.xaml
+++ b/StatsBB/UserControls/StatsView.xaml
@@ -1,6 +1,10 @@
 <UserControl x:Class="StatsBB.UserControls.StatsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:StatsBB.Converters">
+    <UserControl.Resources>
+        <converters:BoolToXConverter x:Key="BoolToXConverter" />
+    </UserControl.Resources>
     <StackPanel Margin="10">
         <Grid Width="1050">
             <Grid.ColumnDefinitions>
@@ -21,10 +25,20 @@
             <TextBlock Text="{Binding HomeTeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
             
         <DataGrid ItemsSource="{Binding HomePlayers}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False" IsReadOnly="True" Width="1050">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsActive}" Value="True">
+                            <Setter Property="FontWeight" Value="Bold"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
                 <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="*"/>
                 <DataGridTextColumn Header="First" Binding="{Binding FirstName}" Width="160"/>
                 <DataGridTextColumn Header="Last" Binding="{Binding LastName}" Width="200"/>
+                <DataGridTextColumn Header="S5" Binding="{Binding S5, Converter={StaticResource BoolToXConverter}}" Width="40"/>
                 <DataGridTextColumn Header="Pts" Binding="{Binding Points}" Width="50"/>
                 <DataGridTextColumn Header="Ast" Binding="{Binding Assists}" Width="50"/>
                 <DataGridTextColumn Header="Reb" Binding="{Binding Rebounds}" Width="50"/>
@@ -80,10 +94,20 @@
 
         <TextBlock Text="{Binding AwayTeamName}" FontWeight="Bold" Margin="10" FontSize="24"/>
         <DataGrid ItemsSource="{Binding AwayPlayers}" AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False" IsReadOnly="True"  Width="1050">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsActive}" Value="True">
+                            <Setter Property="FontWeight" Value="Bold"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
                     <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="*"/>
                     <DataGridTextColumn Header="First" Binding="{Binding FirstName}" Width="160"/>
                     <DataGridTextColumn Header="Last" Binding="{Binding LastName}" Width="200"/>
+                    <DataGridTextColumn Header="S5" Binding="{Binding S5, Converter={StaticResource BoolToXConverter}}" Width="40"/>
                     <DataGridTextColumn Header="Pts" Binding="{Binding Points}" Width="50"/>
                     <DataGridTextColumn Header="Ast" Binding="{Binding Assists}" Width="50"/>
                     <DataGridTextColumn Header="Reb" Binding="{Binding Rebounds}" Width="50"/>


### PR DESCRIPTION
## Summary
- introduce `S5` flag for players to mark starting five
- add starting five selection panel with toggle buttons and OK confirmation
- expose commands and collections in `MainWindowViewModel`
- show starting five indicator and bold active player rows in stats view
- new `BoolToXConverter` for displaying `S5` column

## Testing
- `dotnet build StatsBB/StatsBB.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fbfd3b188326b20ef69e49168487