### PR TITLE
Add period management model

### DIFF
--- a/StatsBB/Domain/Game.cs
+++ b/StatsBB/Domain/Game.cs
@@ -5,12 +5,54 @@ namespace StatsBB.Domain;
 
 public class Game
 {
+    public const int RegularPeriodLength = 10;
+    public const int OvertimeLength = 5;
+    public const int DefaultPeriods = 4;
+    public const int PeriodFoulLimit = 5;
+
     public Guid GameId { get; set; } = Guid.NewGuid();
     public Team? HomeTeam { get; set; }
     public Team? AwayTeam { get; set; }
     public List<Period> Periods { get; set; } = new();
     public int CurrentPeriod { get; set; }
     public List<ActionLogEntry> ActionLog { get; set; } = new();
+
+    public Game()
+    {
+        InitializePeriods(DefaultPeriods);
+    }
+
+    public void InitializePeriods(int count)
+    {
+        Periods.Clear();
+        for (int i = 0; i < count; i++)
+        {
+            Periods.Add(new Period
+            {
+                PeriodNumber = i + 1,
+                Name = $"Q{i + 1}",
+                IsRegular = true,
+                Status = PeriodStatus.Setup,
+                Length = TimeSpan.FromMinutes(RegularPeriodLength)
+            });
+        }
+        CurrentPeriod = 0;
+    }
+
+    public Period AddOvertimePeriod()
+    {
+        int otCount = Periods.FindAll(p => !p.IsRegular).Count + 1;
+        var period = new Period
+        {
+            PeriodNumber = Periods.Count + 1,
+            Name = $"OT{otCount}",
+            IsRegular = false,
+            Status = PeriodStatus.Setup,
+            Length = TimeSpan.FromMinutes(OvertimeLength)
+        };
+        Periods.Add(period);
+        return period;
+    }
 
     public Period GetCurrentPeriod() =>
         CurrentPeriod >= 0 && CurrentPeriod < Periods.Count

--- a/StatsBB/Domain/Period.cs
+++ b/StatsBB/Domain/Period.cs
@@ -5,12 +5,20 @@ namespace StatsBB.Domain;
 public class Period
 {
     public int PeriodNumber { get; set; }
-    public TimeSpan Duration { get; set; }
-    public int HomeTeamFouls { get; set; }
-    public int AwayTeamFouls { get; set; }
+    public string Name { get; set; } = string.Empty;
+    /// <summary>
+    /// True if the period is one of the regular quarters. Overtime
+    /// periods are marked with <c>false</c>.
+    /// </summary>
+    public bool IsRegular { get; set; }
+    public PeriodStatus Status { get; set; } = PeriodStatus.Setup;
+    public TimeSpan Length { get; set; }
+
+    public int HomeFouls { get; set; }
+    public int AwayFouls { get; set; }
     public int HomeTimeoutsTaken { get; set; }
     public int AwayTimeoutsTaken { get; set; }
 
-    public int HomeTeamPoints { get; set; }
-    public int AwayTeamPoints { get; set; }
+    public int HomePeriodScore { get; set; }
+    public int AwayPeriodScore { get; set; }
 }

--- a/StatsBB/Domain/PeriodStatus.cs
+++ b/StatsBB/Domain/PeriodStatus.cs
@@ -1,0 +1,8 @@
+namespace StatsBB.Domain;
+
+public enum PeriodStatus
+{
+    Setup = 0,
+    Active = 1,
+    Ended = 2
+}

--- a/StatsBB/Domain/Team.cs
+++ b/StatsBB/Domain/Team.cs
@@ -57,9 +57,9 @@ public class Team
     public void AddFoul(Period currentPeriod)
     {
         if (IsHomeTeam)
-            currentPeriod.HomeTeamFouls++;
+            currentPeriod.HomeFouls++;
         else
-            currentPeriod.AwayTeamFouls++;
+            currentPeriod.AwayFouls++;
     }
 
     public void AddTimeout(Period currentPeriod)

--- a/StatsBB/Services/ActionProcessor.cs
+++ b/StatsBB/Services/ActionProcessor.cs
@@ -45,9 +45,9 @@ public class ActionProcessor
                     assistingPlayer.AddAssist();
                 team.AddPoints(points);
                 if (team.IsHomeTeam)
-                    period.HomeTeamPoints += points;
+                    period.HomePeriodScore += points;
                 else
-                    period.AwayTeamPoints += points;
+                    period.AwayPeriodScore += points;
                 break;
             case ActionType.ShotMissed:
                 player.AddShotAttempt(isThreePoint);
@@ -82,9 +82,9 @@ public class ActionProcessor
                 player.AddPoints(1);
                 team.AddPoints(1);
                 if (team.IsHomeTeam)
-                    period.HomeTeamPoints += 1;
+                    period.HomePeriodScore += 1;
                 else
-                    period.AwayTeamPoints += 1;
+                    period.AwayPeriodScore += 1;
                 break;
             case ActionType.FreeThrowMissed:
                 player.AddFreeThrowAttempt();

--- a/StatsBB/ViewModel/StatsTabViewModel.cs
+++ b/StatsBB/ViewModel/StatsTabViewModel.cs
@@ -33,8 +33,8 @@ public class StatsTabViewModel : ViewModelBase
     public int HomeScore => Game.HomeTeam?.Points ?? 0;
     public int AwayScore => Game.AwayTeam?.Points ?? 0;
 
-    private int GetHomePeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.HomeTeamPoints ?? 0;
-    private int GetAwayPeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.AwayTeamPoints ?? 0;
+    private int GetHomePeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.HomePeriodScore ?? 0;
+    private int GetAwayPeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.AwayPeriodScore ?? 0;
 
     public int HomeP1 => GetHomePeriod(0);
     public int HomeP2 => GetHomePeriod(1);


### PR DESCRIPTION
## Summary
- introduce `PeriodStatus` enum
- expand `Period` model with metadata for status, type, fouls and scores
- add game constants and methods to initialize periods
- update foul and scoring logic to use new fields
- adjust stats tab to read updated properties

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687110a202fc83269f3fc57f73832510