### PR TITLE
Add period management model

### DIFF
--- a/StatsBB/Domain/Game.cs
+++ b/StatsBB/Domain/Game.cs
@@ -5,12 +5,54 @@ namespace StatsBB.Domain;
 
 public class Game
 {
+    public const int RegularPeriodLength = 10;
+    public const int OvertimeLength = 5;
+    public const int DefaultPeriods = 4;
+    public const int PeriodFoulLimit = 5;
+
     public Guid GameId { get; set; } = Guid.NewGuid();
     public Team? HomeTeam { get; set; }
     public Team? AwayTeam { get; set; }
     public List<Period> Periods { get; set; } = new();
     public int CurrentPeriod { get; set; }
     public List<ActionLogEntry> ActionLog { get; set; } = new();
+
+    public Game()
+    {
+        InitializePeriods(DefaultPeriods);
+    }
+
+    public void InitializePeriods(int count)
+    {
+        Periods.Clear();
+        for (int i = 0; i < count; i++)
+        {
+            Periods.Add(new Period
+            {
+                PeriodNumber = i + 1,
+                Name = $"Q{i + 1}",
+                IsRegular = true,
+                Status = PeriodStatus.Setup,
+                Length = TimeSpan.FromMinutes(RegularPeriodLength)
+            });
+        }
+        CurrentPeriod = 0;
+    }
+
+    public Period AddOvertimePeriod()
+    {
+        int otCount = Periods.FindAll(p => !p.IsRegular).Count + 1;
+        var period = new Period
+        {
+            PeriodNumber = Periods.Count + 1,
+            Name = $"OT{otCount}",
+            IsRegular = false,
+            Status = PeriodStatus.Setup,
+            Length = TimeSpan.FromMinutes(OvertimeLength)
+        };
+        Periods.Add(period);
+        return period;
+    }
 
     public Period GetCurrentPeriod() =>
         CurrentPeriod >= 0 && CurrentPeriod < Periods.Count

--- a/StatsBB/Domain/Period.cs
+++ b/StatsBB/Domain/Period.cs
@@ -5,12 +5,20 @@ namespace StatsBB.Domain;
 public class Period
 {
     public int PeriodNumber { get; set; }
-    public TimeSpan Duration { get; set; }
-    public int HomeTeamFouls { get; set; }
-    public int AwayTeamFouls { get; set; }
+    public string Name { get; set; } = string.Empty;
+    /// <summary>
+    /// True if the period is one of the regular quarters. Overtime
+    /// periods are marked with <c>false</c>.
+    /// </summary>
+    public bool IsRegular { get; set; }
+    public PeriodStatus Status { get; set; } = PeriodStatus.Setup;
+    public TimeSpan Length { get; set; }
+
+    public int HomeFouls { get; set; }
+    public int AwayFouls { get; set; }
     public int HomeTimeoutsTaken { get; set; }
     public int AwayTimeoutsTaken { get; set; }
 
-    public int HomeTeamPoints { get; set; }
-    public int AwayTeamPoints { get; set; }
+    public int HomePeriodScore { get; set; }
+    public int AwayPeriodScore { get; set; }
 }

--- a/StatsBB/Domain/PeriodStatus.cs
+++ b/StatsBB/Domain/PeriodStatus.cs
@@ -1,0 +1,8 @@
+namespace StatsBB.Domain;
+
+public enum PeriodStatus
+{
+    Setup = 0,
+    Active = 1,
+    Ended = 2
+}

--- a/StatsBB/Domain/Team.cs
+++ b/StatsBB/Domain/Team.cs
@@ -57,9 +57,9 @@ public class Team
     public void AddFoul(Period currentPeriod)
     {
         if (IsHomeTeam)
-            currentPeriod.HomeTeamFouls++;
+            currentPeriod.HomeFouls++;
         else
-            currentPeriod.AwayTeamFouls++;
+            currentPeriod.AwayFouls++;
     }
 
     public void AddTimeout(Period currentPeriod)

--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -401,7 +401,7 @@
 
             <controls:TeamInfoView DataContext="{Binding TeamInfoVM}" />
         </TabItem>
-        <TabItem Header="MAIN">
+        <TabItem Header="MAIN" IsEnabled="{Binding AreTeamsConfirmed}">
             <Grid x:Name="___No_Name_" Background="#F9F9F9">
                 <!-- Layout: Header, Event Buttons, Main Content -->
                 <Grid.RowDefinitions>
@@ -418,14 +418,6 @@
                 <controls:ScoreBoardView Grid.Row="0" Grid.Column="0"
                                          DataContext="{Binding ScoreBoardVM}" />
 
-                <!-- Game Setup Panel -->
-                <Grid Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
-                      Visibility="{Binding GamePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="20">
-                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Button Content="SETUP GAME" FontSize="24" FontWeight="Bold" Padding="20"
-                                Command="{Binding SetupGameCommand}"/>
-                    </StackPanel>
-                </Grid>
 
                 <Grid Grid.Row="1" Grid.Column="0" Margin="10">
                     <Grid.RowDefinitions>
@@ -443,6 +435,14 @@
                         <controls:Court x:Name="CourtControl"
                     VerticalAlignment="Stretch"
                     HorizontalAlignment="Stretch" />
+
+                        <!-- Game Setup Panel -->
+                        <Grid Visibility="{Binding GamePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Button Content="SETUP GAME" FontSize="24" FontWeight="Bold" Padding="20"
+                                        Command="{Binding SetupGameCommand}"/>
+                            </StackPanel>
+                        </Grid>
 
                         <!-- Quick Shot Panel -->
                         <Grid Visibility="{Binding QuickShotPanelVisibility}"
@@ -1664,7 +1664,7 @@ Margin="4" />
                 </Border>
             </Grid>
         </TabItem>
-        <TabItem Header="STATS">
+        <TabItem Header="STATS" IsEnabled="{Binding AreTeamsConfirmed}">
             <controls:StatsView DataContext="{Binding StatsVM}" />
         </TabItem>
     </TabControl>

--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -415,8 +415,17 @@
 
                 <!-- ========= Row 0: Team Cards & Clock ========= -->
 
-                <controls:ScoreBoardView Grid.Row="0" Grid.Column="0" 
+                <controls:ScoreBoardView Grid.Row="0" Grid.Column="0"
                                          DataContext="{Binding ScoreBoardVM}" />
+
+                <!-- Game Setup Panel -->
+                <Grid Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
+                      Visibility="{Binding GamePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="20">
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Button Content="SETUP GAME" FontSize="24" FontWeight="Bold" Padding="20"
+                                Command="{Binding SetupGameCommand}"/>
+                    </StackPanel>
+                </Grid>
 
                 <Grid Grid.Row="1" Grid.Column="0" Margin="10">
                     <Grid.RowDefinitions>

--- a/StatsBB/Services/ActionProcessor.cs
+++ b/StatsBB/Services/ActionProcessor.cs
@@ -45,9 +45,9 @@ public class ActionProcessor
                     assistingPlayer.AddAssist();
                 team.AddPoints(points);
                 if (team.IsHomeTeam)
-                    period.HomeTeamPoints += points;
+                    period.HomePeriodScore += points;
                 else
-                    period.AwayTeamPoints += points;
+                    period.AwayPeriodScore += points;
                 break;
             case ActionType.ShotMissed:
                 player.AddShotAttempt(isThreePoint);
@@ -82,9 +82,9 @@ public class ActionProcessor
                 player.AddPoints(1);
                 team.AddPoints(1);
                 if (team.IsHomeTeam)
-                    period.HomeTeamPoints += 1;
+                    period.HomePeriodScore += 1;
                 else
-                    period.AwayTeamPoints += 1;
+                    period.AwayPeriodScore += 1;
                 break;
             case ActionType.FreeThrowMissed:
                 player.AddFreeThrowAttempt();

--- a/StatsBB/Services/GameClockService.cs
+++ b/StatsBB/Services/GameClockService.cs
@@ -104,5 +104,5 @@ public static class GameClockService
         TimeUpdated?.Invoke();
     }
 
-    public static string TimeLeftString => $"{Period} {(int)TimeLeft.TotalMinutes:D2}:{TimeLeft.Seconds:D2}";
+    public static string TimeLeftString => $"{(int)TimeLeft.TotalMinutes:D2}:{TimeLeft.Seconds:D2}";
 }

--- a/StatsBB/Services/GameClockService.cs
+++ b/StatsBB/Services/GameClockService.cs
@@ -17,6 +17,19 @@ public static class GameClockService
     public static string Period { get; private set; } = "Q1";
     public static bool IsRunning => _timer.IsEnabled;
 
+    public static string StartStopLabel { get; private set; } = "START";
+    public static bool StartStopEnabled { get; private set; } = true;
+
+    public static event Action? EndPeriodRequested;
+    public static event Action? FinalizeGameRequested;
+
+    public static void SetState(string label, bool enabled)
+    {
+        StartStopLabel = label;
+        StartStopEnabled = enabled;
+        TimeUpdated?.Invoke();
+    }
+
     public static event Action? TimeUpdated;
 
     private static void Tick()
@@ -36,6 +49,8 @@ public static class GameClockService
     {
         if (!IsRunning)
             _timer.Start();
+        StartStopLabel = "STOP";
+        StartStopEnabled = true;
         TimeUpdated?.Invoke();
     }
 
@@ -43,21 +58,49 @@ public static class GameClockService
     {
         if (IsRunning)
             _timer.Stop();
+
+        if (TimeLeft == TimeSpan.Zero)
+        {
+            StartStopLabel = "END PERIOD";
+            StartStopEnabled = true;
+        }
+        else
+        {
+            StartStopLabel = "START";
+            StartStopEnabled = true;
+        }
+
         TimeUpdated?.Invoke();
     }
 
     public static void Toggle()
     {
+        if (!StartStopEnabled)
+            return;
+
+        if (StartStopLabel == "END PERIOD")
+        {
+            EndPeriodRequested?.Invoke();
+            return;
+        }
+        if (StartStopLabel == "FINALIZE GAME")
+        {
+            FinalizeGameRequested?.Invoke();
+            return;
+        }
+
         if (IsRunning)
             Stop();
         else
             Start();
     }
 
-    public static void Reset(TimeSpan? periodLength = null, String? periodName = null)
+    public static void Reset(TimeSpan? periodLength = null, string? periodName = null, string? label = "START")
     {
-        Period = periodName ?? "=Q1";
+        Period = periodName ?? "Q1";
         TimeLeft = periodLength ?? TimeSpan.FromMinutes(10);
+        StartStopLabel = label ?? "START";
+        StartStopEnabled = true;
         TimeUpdated?.Invoke();
     }
 

--- a/StatsBB/UserControls/GameClock.xaml.cs
+++ b/StatsBB/UserControls/GameClock.xaml.cs
@@ -24,8 +24,11 @@ public partial class GameClock : UserControl
     {
         TimeText.Text = GameClockService.TimeLeftString;
         PeriodText.Text = GameClockService.Period;
-        StartStopButton.Content = GameClockService.IsRunning ? "STOP" : "START";
-        StartStopButton.Background = GameClockService.IsRunning ? Brushes.Green : Brushes.Red;
+        StartStopButton.Content = GameClockService.StartStopLabel;
+        StartStopButton.IsEnabled = GameClockService.StartStopEnabled;
+        StartStopButton.Background = GameClockService.IsRunning
+            ? Brushes.Green
+            : GameClockService.StartStopEnabled ? Brushes.Red : Brushes.LightGray;
     }
 
     public void Toggle() => StartStop_Click(this, new RoutedEventArgs());

--- a/StatsBB/UserControls/TeamInfoView.xaml
+++ b/StatsBB/UserControls/TeamInfoView.xaml
@@ -58,7 +58,7 @@
             <TextBlock Text="Team Name" FontWeight="Bold" FontSize="14" Margin="5"/>
             <TextBox Text="{Binding HomeTeamName, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="18"  Width="250" HorizontalAlignment="Left"/>
             <TextBlock Text="Team Color" FontWeight="Bold" FontSize="14" Margin="5"/>
-            <ItemsControl ItemsSource="{Binding ColorOptions}">
+            <ItemsControl ItemsSource="{Binding ColorOptions}" IsEnabled="{Binding HomeColorEnabled}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <WrapPanel ItemWidth="54" ItemHeight="54" Width="550"/>
@@ -108,6 +108,7 @@
             <StackPanel Orientation="Horizontal" Margin="5">
                 <Button Content="Load Team" Command="{Binding LoadHomeTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
                 <Button Content="Save Team" Command="{Binding SaveHomeTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
+                <Button Content="Confirm Team" Command="{Binding ConfirmHomeTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
             </StackPanel>
         </StackPanel>
         </Border>
@@ -117,7 +118,7 @@
             <TextBlock Text="Team Name" FontWeight="Bold" FontSize="14" Margin="5"/>
             <TextBox Text="{Binding AwayTeamName, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="18" Width="250" HorizontalAlignment="Left"/>
             <TextBlock Text="Team Color" FontWeight="Bold" FontSize="14" Margin="5"/>
-            <ItemsControl ItemsSource="{Binding ColorOptions}">
+            <ItemsControl ItemsSource="{Binding ColorOptions}" IsEnabled="{Binding AwayColorEnabled}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                             <WrapPanel ItemWidth="54" ItemHeight="54" Width="550"/>
@@ -167,6 +168,7 @@
             <StackPanel Orientation="Horizontal" Margin="5">
                 <Button Content="Load Team" Command="{Binding LoadAwayTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
                 <Button Content="Save Team" Command="{Binding SaveAwayTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
+                <Button Content="Confirm Team" Command="{Binding ConfirmAwayTeamCommand}" FontSize="16" FontWeight="Bold" Padding="10" Margin="5"/>
             </StackPanel>
         </StackPanel>
         </Border>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -248,6 +248,8 @@ public class MainWindowViewModel : ViewModelBase
     public Visibility GamePanelVisibility =>
         IsGamePanelVisible ? Visibility.Visible : Visibility.Collapsed;
 
+    public bool AreTeamsConfirmed => TeamInfoVM.AreTeamsConfirmed;
+
     private readonly ResourceDictionary _resources;
 
     public ICommand SelectActionCommand { get; }
@@ -416,6 +418,12 @@ public class MainWindowViewModel : ViewModelBase
                 TeamBShortName = TeamBInfo.ShortName;
             if (e.PropertyName == nameof(TeamInfo.Color) && TeamBColorOption != TeamBInfo.Color)
                 TeamBColorOption = TeamBInfo.Color;
+        };
+
+        TeamInfoVM.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(TeamInfoViewModel.AreTeamsConfirmed))
+                OnPropertyChanged(nameof(AreTeamsConfirmed));
         };
 
         Game.HomeTeam.Players.CollectionChanged += TeamPlayersChanged;

--- a/StatsBB/ViewModel/StatsTabViewModel.cs
+++ b/StatsBB/ViewModel/StatsTabViewModel.cs
@@ -33,8 +33,8 @@ public class StatsTabViewModel : ViewModelBase
     public int HomeScore => Game.HomeTeam?.Points ?? 0;
     public int AwayScore => Game.AwayTeam?.Points ?? 0;
 
-    private int GetHomePeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.HomeTeamPoints ?? 0;
-    private int GetAwayPeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.AwayTeamPoints ?? 0;
+    private int GetHomePeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.HomePeriodScore ?? 0;
+    private int GetAwayPeriod(int index) => Game.Periods.ElementAtOrDefault(index)?.AwayPeriodScore ?? 0;
 
     public int HomeP1 => GetHomePeriod(0);
     public int HomeP2 => GetHomePeriod(1);

--- a/StatsBB/ViewModel/TeamInfoViewModel.cs
+++ b/StatsBB/ViewModel/TeamInfoViewModel.cs
@@ -18,6 +18,40 @@ public class TeamInfoViewModel : ViewModelBase
     public RelayCommand SaveHomeTeamCommand { get; }
     public RelayCommand LoadAwayTeamCommand { get; }
     public RelayCommand SaveAwayTeamCommand { get; }
+    public RelayCommand ConfirmHomeTeamCommand { get; }
+    public RelayCommand ConfirmAwayTeamCommand { get; }
+
+    private bool _homeTeamConfirmed;
+    public bool HomeTeamConfirmed
+    {
+        get => _homeTeamConfirmed;
+        set
+        {
+            if (_homeTeamConfirmed == value) return;
+            _homeTeamConfirmed = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HomeColorEnabled));
+            OnPropertyChanged(nameof(AreTeamsConfirmed));
+        }
+    }
+
+    private bool _awayTeamConfirmed;
+    public bool AwayTeamConfirmed
+    {
+        get => _awayTeamConfirmed;
+        set
+        {
+            if (_awayTeamConfirmed == value) return;
+            _awayTeamConfirmed = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(AwayColorEnabled));
+            OnPropertyChanged(nameof(AreTeamsConfirmed));
+        }
+    }
+
+    public bool AreTeamsConfirmed => HomeTeamConfirmed && AwayTeamConfirmed;
+    public bool HomeColorEnabled => !HomeTeamConfirmed;
+    public bool AwayColorEnabled => !AwayTeamConfirmed;
     public TeamInfoViewModel(MainWindowViewModel main)
     {
         _main = main;
@@ -33,6 +67,8 @@ public class TeamInfoViewModel : ViewModelBase
         SaveHomeTeamCommand = new RelayCommand(_ => SaveTeam(Game.HomeTeam));
         LoadAwayTeamCommand = new RelayCommand(_ => LoadTeam(Game.AwayTeam, false));
         SaveAwayTeamCommand = new RelayCommand(_ => SaveTeam(Game.AwayTeam));
+        ConfirmHomeTeamCommand = new RelayCommand(_ => HomeTeamConfirmed = true);
+        ConfirmAwayTeamCommand = new RelayCommand(_ => AwayTeamConfirmed = true);
     }
 
     private static void EnsurePlayers(Team team)


### PR DESCRIPTION
## Summary
- introduce `PeriodStatus` enum
- expand `Period` model with metadata for status, type, fouls and scores
- add game constants and methods to initialize periods
- update foul and scoring logic to use new fields
- adjust stats tab to read updated properties

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687110a202fc83269f3fc57f73832510