### PR TITLE
Add jump ball selection panels

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1301,6 +1301,127 @@ Margin="4" />
                                 </StackPanel>
                             </StackPanel>
                         </Grid>
+                        <!-- Jump Ball Panel -->
+                        <Grid Visibility="{Binding JumpBallPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="Auto">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="160"/>
+                                        <ColumnDefinition Width="100"/>
+                                        <ColumnDefinition Width="80"/>
+                                        <ColumnDefinition Width="100"/>
+                                        <ColumnDefinition Width="160"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="30" />
+                                        <RowDefinition Height="400" />
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="COURT" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="JUMPING" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="JUMPING" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="4" Text="COURT" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+
+                                    <!-- Team A Court -->
+                                    <Border Grid.Row="1" Grid.Column="0" Background="#cceeeeee" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamACourtPlayers}"  VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" FlowDirection="RightToLeft" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtAPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleJumpPlayerCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+
+                                    <!-- Team A Jumping -->
+                                    <Border Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamAJumpingPlayers}"  VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" FlowDirection="RightToLeft" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtAPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleJumpPlayerCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+
+                                    <!-- Jump Button -->
+                                    <WrapPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <Button Content="JUMP" Width="60" Height="60" FontSize="16" FontWeight="Bold" Background="DarkGreen" Foreground="White" Command="{Binding ConfirmJumpBallCommand}" IsEnabled="{Binding IsJumpEnabled}"/>
+                                    </WrapPanel>
+
+                                    <!-- Team B Jumping -->
+                                    <Border Grid.Row="1" Grid.Column="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamBJumpingPlayers}"  VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtBPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleJumpPlayerCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+
+                                    <!-- Team B Court -->
+                                    <Border Grid.Row="1" Grid.Column="4" Background="#cceeeeee" HorizontalAlignment="Stretch" VerticalAlignment="Center" Height="380" Margin="2">
+                                        <ItemsControl ItemsSource="{Binding TeamBCourtPlayers}"  VerticalAlignment="Center" HorizontalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Vertical" Height="360"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding DisplayName}"
+                                                            Style="{StaticResource CourtBPlayerButtonStyle}"
+                                                            Command="{Binding DataContext.ToggleJumpPlayerCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                            CommandParameter="{Binding}"
+                                                            Margin="4" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
+                        <!-- Jump Winner Panel -->
+                        <Grid Visibility="{Binding JumpWinnerPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                                <TextBlock Text="WHO WON?" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                    <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+                                        <Button Content="{Binding TeamAName}" Command="{Binding JumpTeamACommand}" Style="{StaticResource TeamAReboundStyle}"/>
+                                    </Border>
+                                    <Border Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2">
+                                        <Button Content="{Binding TeamBName}" Command="{Binding JumpTeamBCommand}" Style="{StaticResource TeamBReboundStyle}"/>
+                                    </Border>
+                                </StackPanel>
+                            </StackPanel>
+                        </Grid>
                         <!-- Starting Five Panel -->
                         <Grid Visibility="{Binding StartingFivePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="Auto">
@@ -1639,7 +1760,7 @@ Margin="4" />
                         <Button Content="FOUL (E)" Style="{StaticResource Foul}" Command="{Binding SelectActionCommand}" CommandParameter="Foul"/>
                         <Button Content="TURNOVER (R)" Style="{StaticResource Turnover}" Command="{Binding StartTurnoverCommand}"/>
                         <Button Content="TIME OUT" Style="{StaticResource TimeOut}" Command="{Binding StartTimeoutCommand}"/>
-                        <Button Content="JUMP BALL" Style="{StaticResource JumpBall}"/>
+                        <Button Content="JUMP BALL" Style="{StaticResource JumpBall}" Command="{Binding StartJumpBallCommand}"/>
                         <Button Content="SUBSTITUTIONS" Style="{StaticResource Sub}" Command="{Binding StartSubstitutionCommand}"/>
                         <Button Content="S5" Style="{StaticResource Sub}" Command="{Binding StartStartingFiveCommand}"/>
                         <Button Content="FREE THROWS" Style="{StaticResource FreeThrows}" Command="{Binding StartFreeThrowsCommand}"/>


### PR DESCRIPTION
## Summary
- implement jump ball flow in `MainWindowViewModel`
- add UI for jump ball selection and result panels
- wire up Jump Ball button to open the new screen

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687115b6b2b483269e00f8bc264ba491