### PR TITLE
Add rebound type selection overlay

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -275,6 +275,8 @@
             <Setter Property="Height" Value="60" />
             <Setter Property="Width" Value="280" />
         </Style>
+        <!-- REBOUND TYPE BUTTON -->
+        <Style x:Key="ReboundTypeButtonStyle" TargetType="Button" BasedOn="{StaticResource FoulTypeButtonStyle}"/>
         <!-- FREE THROW COUNT BUTTON -->
         <Style x:Key="FreeThrowCountButtonStyle" TargetType="Button" BasedOn="{StaticResource FoulTypeButtonStyle}">
             <Setter Property="Width" Value="60" />
@@ -713,6 +715,16 @@ Margin="4" />
                                     </StackPanel>
                                 </Border>
                             </Grid>
+                        </Grid>
+
+                        <Grid Visibility="{Binding ReboundTypePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10" Width="400" Height="200">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock Text="TYPE OF REBOUND" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="10"/>
+                                <WrapPanel HorizontalAlignment="Center">
+                                    <Button Style="{StaticResource ReboundTypeButtonStyle}" Content="OFFENSIVE" Command="{Binding SelectReboundTypeCommand}" CommandParameter="offensive"/>
+                                    <Button Style="{StaticResource ReboundTypeButtonStyle}" Content="DEFENSIVE" Command="{Binding SelectReboundTypeCommand}" CommandParameter="defensive"/>
+                                </WrapPanel>
+                            </StackPanel>
                         </Grid>
 
                         <Grid Visibility="{Binding BlockerSelectionVisibility}"

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1159,6 +1159,27 @@ public class MainWindowViewModel : ViewModelBase
             AddPlayCard(_currentPlayActions.ToList());
             _currentPlayActions.Clear();
         }
+        else
+        {
+            if (reboundSource is Player rp)
+            {
+                _currentPlayActions.Add(CreateAction(rp, "REBOUND"));
+                bool offensive = _pendingReboundOffensive ?? false;
+                _actionProcessor.Process(offensive ? ActionType.OffensiveRebound : ActionType.DefensiveRebound, rp);
+                StatsVM.Refresh();
+            }
+            else if (reboundSource is string team && (team == "TeamA" || team == "TeamB"))
+            {
+                bool teamA = team == "TeamA";
+                _currentPlayActions.Add(CreateTeamAction(teamA, "REBOUND"));
+                bool offensive = _pendingReboundOffensive ?? false;
+                var t = teamA ? Game.HomeTeam : Game.AwayTeam;
+                _actionProcessor.ProcessTeam(ActionType.TeamRebound, t, offensive);
+                StatsVM.Refresh();
+            }
+            AddPlayCard(_currentPlayActions.ToList());
+            _currentPlayActions.Clear();
+        }
 
         ResetSelectionState();
     }

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -801,7 +801,18 @@ public class MainWindowViewModel : ViewModelBase
     {
         _pendingReboundSource = reboundSource;
         IsReboundSelectionActive = false;
-        IsReboundTypeSelectionActive = true;
+
+        if (_pendingShooter == null)
+        {
+            // Manual rebound flow – ask for offensive/defensive type
+            IsReboundTypeSelectionActive = true;
+        }
+        else
+        {
+            // Rebound after a missed/blocked shot – use automatic logic
+            CompleteReboundSelection(reboundSource);
+            _pendingReboundSource = null;
+        }
     }
 
     private void OnReboundTypeSelected(string? reboundType)


### PR DESCRIPTION
## Summary
- implement Rebound Type selection flow
- add new command and VM properties for rebound type
- reset state properly when cancelling
- add XAML for the new panel with Offensive/Defensive options

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687115e180188326b0e19d19c53f35ea