### PR TITLE
Implement assist team selection

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -533,6 +533,25 @@
                             </Grid>
                         </Grid>
 
+                        <!-- Assist Team Selection -->
+                        <Grid Visibility="{Binding AssistTeamPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                                <TextBlock Text="SELECT TEAM" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Border Grid.Column="0">
+                                        <Button Content="{Binding TeamAName}" Command="{Binding AssistTeamACommand}" Style="{StaticResource TeamAReboundStyle}" Margin="5"/>
+                                    </Border>
+                                    <Border Grid.Column="1">
+                                        <Button Content="{Binding TeamBName}" Command="{Binding AssistTeamBCommand}" Style="{StaticResource TeamBReboundStyle}" Margin="5"/>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
+
                         <!-- Assist Panel -->
                         <Grid Visibility="{Binding NoAssistButtonVisibility}"
       Panel.ZIndex="10" Background="#ccFFFFFF">

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -238,6 +238,8 @@ public class MainWindowViewModel : ViewModelBase
 
     public ICommand SelectActionCommand { get; }
     public ICommand NoAssistCommand { get; }
+    public ICommand AssistTeamACommand { get; }
+    public ICommand AssistTeamBCommand { get; }
     public ICommand ReboundTeamACommand { get; }
     public ICommand ReboundTeamBCommand { get; }
     public ICommand BlockCommand { get; }
@@ -298,6 +300,8 @@ public class MainWindowViewModel : ViewModelBase
             _ => CompleteAssistSelection(null),
             _ => IsAssistSelectionActive
         );
+        AssistTeamACommand = new RelayCommand(_ => SelectAssistTeam(true), _ => IsAssistTeamSelectionActive);
+        AssistTeamBCommand = new RelayCommand(_ => SelectAssistTeam(false), _ => IsAssistTeamSelectionActive);
         NoStealCommand = new RelayCommand(
             _ => CompleteStealSelection(null),
             _ => IsStealSelectionActive
@@ -459,6 +463,20 @@ public class MainWindowViewModel : ViewModelBase
     private void BeginAssist()
     {
         ResetSelectionState();
+        if (_pendingShooter == null)
+        {
+            IsAssistTeamSelectionActive = true;
+        }
+        else
+        {
+            IsAssistSelectionActive = true;
+        }
+    }
+
+    private void SelectAssistTeam(bool teamA)
+    {
+        _assistTeamIsTeamA = teamA;
+        IsAssistTeamSelectionActive = false;
         IsAssistSelectionActive = true;
     }
 
@@ -650,6 +668,7 @@ public class MainWindowViewModel : ViewModelBase
     private int _selectedFreeThrowCount;
     private Player? _selectedFreeThrowShooter;
     private Player? _selectedFreeThrowAssist;
+    private bool _assistTeamIsTeamA;
     private readonly List<PlayActionViewModel> _currentPlayActions = new();
 
     private void OnPlayerSelected(Player player)
@@ -1035,6 +1054,7 @@ public class MainWindowViewModel : ViewModelBase
         SelectedPoint = null;
         _pendingShooter = null;
         IsAssistSelectionActive = false;
+        IsAssistTeamSelectionActive = false;
         IsReboundSelectionActive = false;
         IsTurnoverSelectionActive = false;
         IsStealSelectionActive = false;
@@ -1074,11 +1094,19 @@ public class MainWindowViewModel : ViewModelBase
             AddPlayCard(_currentPlayActions.ToList());
             _currentPlayActions.Clear();
         }
+        else if (assistPlayer != null)
+        {
+            Debug.WriteLine($"{GameClockService.TimeLeftString} Assist by {assistPlayer.Number}.{assistPlayer.Name}");
+            AddPlayCard(new[] { CreateAction(assistPlayer, "ASSIST") });
+            _actionProcessor.Process(ActionType.Assist, assistPlayer);
+            StatsVM.Refresh();
+        }
 
         _pendingShooter = null;
         SelectedAction = null;
         SelectedPoint = null;
         IsAssistSelectionActive = false;
+        IsAssistTeamSelectionActive = false;
     }
 
     private void CompleteReboundSelection(object? reboundSource)
@@ -1332,6 +1360,18 @@ public class MainWindowViewModel : ViewModelBase
     public bool IsPlayerSelectionActive => SelectedPoint != null && !string.IsNullOrEmpty(SelectedAction);
     public bool IsActionSelectionActive => SelectedPoint != null;
 
+    private bool _isAssistTeamSelectionActive;
+    public bool IsAssistTeamSelectionActive
+    {
+        get => _isAssistTeamSelectionActive;
+        set
+        {
+            _isAssistTeamSelectionActive = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(AssistTeamPanelVisibility));
+        }
+    }
+
     private bool _isAssistSelectionActive;
     public bool IsAssistSelectionActive
     {
@@ -1345,6 +1385,9 @@ public class MainWindowViewModel : ViewModelBase
         }
     }
 
+    public Visibility AssistTeamPanelVisibility =>
+        IsAssistTeamSelectionActive ? Visibility.Visible : Visibility.Collapsed;
+
     private void UpdateAssistPlayerStyles()
     {
         EligibleCourtAssistPlayers.Clear();
@@ -1352,6 +1395,24 @@ public class MainWindowViewModel : ViewModelBase
 
         if (_pendingShooter == null)
         {
+            if (!IsAssistSelectionActive)
+            {
+                OnPropertyChanged(nameof(EligibleCourtAssistPlayers));
+                OnPropertyChanged(nameof(EligibleBenchAssistPlayers));
+                return;
+            }
+
+            var players = _assistTeamIsTeamA ? TeamAPlayers : TeamBPlayers;
+            foreach (var vm in players)
+            {
+                vm.SetAssistSelectionMode(IsAssistSelectionActive);
+                vm.IsSelectedAsAssist = false;
+                if (vm.Player.IsActive)
+                    EligibleCourtAssistPlayers.Add(vm);
+                else
+                    EligibleBenchAssistPlayers.Add(vm);
+            }
+
             OnPropertyChanged(nameof(EligibleCourtAssistPlayers));
             OnPropertyChanged(nameof(EligibleBenchAssistPlayers));
             return;


### PR DESCRIPTION
## Summary
- add UI panel to choose assist team
- add viewmodel logic for assist team selection
- handle standalone assist action if no shooter is selected

## Testing
- `dotnet build StatsBB/StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687115d6dbb483268c435850b9576482