### PR TITLE
Add team selection screen for steals

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -887,6 +887,23 @@ Margin="4" />
                                 </Border>
                             </Grid>
                         </Grid>
+                        <Grid Visibility="{Binding StealTeamPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                                <TextBlock Text="SELECT TEAM" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Border Grid.Column="0">
+                                        <Button Content="{Binding TeamAName}" Command="{Binding StealTeamACommand}" Style="{StaticResource TeamAReboundStyle}" Margin="5"/>
+                                    </Border>
+                                    <Border Grid.Column="1">
+                                        <Button Content="{Binding TeamBName}" Command="{Binding StealTeamBCommand}" Style="{StaticResource TeamBReboundStyle}" Margin="5"/>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
                         <Grid Visibility="{Binding StealPanelVisibility}"
       Background="#33FFFFFF"
       Panel.ZIndex="10" Width="400">

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1344,8 +1344,19 @@ public class MainWindowViewModel : ViewModelBase
 
     private void CompleteStealSelection(Player? stealer)
     {
+        // Standalone steal flow when there is no pending turnover
         if (_pendingShooter == null)
+        {
+            if (stealer != null)
+            {
+                Debug.WriteLine($"{GameClockService.TimeLeftString} Steal by {stealer.Number}.{stealer.Name}");
+                AddPlayCard(new[] { CreateAction(stealer, "STEAL") });
+                _actionProcessor.Process(ActionType.Steal, stealer);
+                StatsVM.Refresh();
+            }
+            ResetSelectionState();
             return;
+        }
 
         if (stealer == null)
         {


### PR DESCRIPTION
## Summary
- add team selection step before entering steal selection
- include new StealTeam commands and visibility handling
- filter steal player list based on selected team

## Testing
- `dotnet build StatsBB.sln -v:m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711a9baafc8326b7403373990f7fb5