### PR TITLE
Add free throw team selection

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1085,14 +1085,31 @@ Margin="4" />
                                     <Button Style="{StaticResource FoulTypeButtonStyle}" Content="TECHNICAL" Command="{Binding SelectFoulTypeCommand}" CommandParameter="technical"/>
                                     <Button Style="{StaticResource FoulTypeButtonStyle}" Content="DOUBLE PERSONAL" Command="{Binding SelectFoulTypeCommand}" CommandParameter="double personal"/>
                                     <Button Style="{StaticResource FoulTypeButtonStyle}" Content="UNSPORTSMANLIKE" Command="{Binding SelectFoulTypeCommand}" CommandParameter="unsportsmanlike"/>
-                                    <Button Style="{StaticResource FoulTypeButtonStyle}" Content="DISQUALIFYING" Command="{Binding SelectFoulTypeCommand}" CommandParameter="disqualifying"/>
-                                </WrapPanel>
-                            </StackPanel>
-                        </Grid>
-                        <Grid Visibility="{Binding FreeThrowsAwardedPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
-                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Button Style="{StaticResource FoulTypeButtonStyle}" Content="DISQUALIFYING" Command="{Binding SelectFoulTypeCommand}" CommandParameter="disqualifying"/>
+                            </WrapPanel>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Visibility="{Binding FreeThrowTeamPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                            <TextBlock Text="SELECT TEAM" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Grid.Column="0">
+                                    <Button Content="{Binding TeamAName}" Command="{Binding FreeThrowTeamACommand}" Style="{StaticResource TeamAReboundStyle}" Margin="5"/>
+                                </Border>
+                                <Border Grid.Column="1">
+                                    <Button Content="{Binding TeamBName}" Command="{Binding FreeThrowTeamBCommand}" Style="{StaticResource TeamBReboundStyle}" Margin="5"/>
+                                </Border>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Visibility="{Binding FreeThrowsAwardedPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Border Background="#cceeeeee" Padding="10" Margin="2">
                                     <StackPanel>
                                         <TextBlock Text="Free Throws Awarded" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -301,6 +301,8 @@ public class MainWindowViewModel : ViewModelBase
     public ICommand StartReboundCommand { get; }
     public ICommand StartStealCommand { get; }
     public ICommand StartFreeThrowsCommand { get; }
+    public ICommand FreeThrowTeamACommand { get; }
+    public ICommand FreeThrowTeamBCommand { get; }
     public ICommand NoStealCommand { get; }
     public ICommand SelectFoulTypeCommand { get; }
     public ICommand SelectReboundTypeCommand { get; }
@@ -407,6 +409,8 @@ public class MainWindowViewModel : ViewModelBase
         StartReboundCommand = new RelayCommand(_ => BeginRebound());
         StartStealCommand = new RelayCommand(_ => BeginSteal());
         StartFreeThrowsCommand = new RelayCommand(_ => BeginFreeThrows());
+        FreeThrowTeamACommand = new RelayCommand(_ => SelectFreeThrowTeam(true), _ => IsFreeThrowTeamSelectionActive);
+        FreeThrowTeamBCommand = new RelayCommand(_ => SelectFreeThrowTeam(false), _ => IsFreeThrowTeamSelectionActive);
 
         CoachTechnicalTeamACommand = new RelayCommand(_ => OnCoachTechnical("Team A"));
         CoachTechnicalTeamBCommand = new RelayCommand(_ => OnCoachTechnical("Team B"));
@@ -598,6 +602,13 @@ public class MainWindowViewModel : ViewModelBase
         IsAssistSelectionActive = true;
     }
 
+    private void SelectFreeThrowTeam(bool teamA)
+    {
+        _freeThrowTeamIsTeamA = teamA;
+        IsFreeThrowTeamSelectionActive = false;
+        BeginFreeThrowsAwardedSelection();
+    }
+
     private void BeginRebound()
     {
         ResetSelectionState();
@@ -613,7 +624,14 @@ public class MainWindowViewModel : ViewModelBase
     private void BeginFreeThrows()
     {
         ResetSelectionState();
-        BeginFreeThrowsAwardedSelection();
+        if (_fouledPlayer == null)
+        {
+            IsFreeThrowTeamSelectionActive = true;
+        }
+        else
+        {
+            BeginFreeThrowsAwardedSelection();
+        }
     }
 
     private void CompleteTimeoutSelection(string team)
@@ -789,6 +807,7 @@ public class MainWindowViewModel : ViewModelBase
     private Player? _selectedFreeThrowShooter;
     private Player? _selectedFreeThrowAssist;
     private bool _assistTeamIsTeamA;
+    private bool _isFreeThrowTeamSelectionActive;
     private readonly List<PlayActionViewModel> _currentPlayActions = new();
 
     private void OnPlayerSelected(Player player)
@@ -1036,6 +1055,7 @@ public class MainWindowViewModel : ViewModelBase
         IsFoulCommiterSelectionActive = false;
         IsFoulTypeSelectionActive = false;
         IsFouledPlayerSelectionActive = false;
+        IsFreeThrowTeamSelectionActive = false;
         IsFreeThrowsAwardedSelectionActive = false;
         FreeThrowResultRows.Clear();
         IsFreeThrowsSelectionActive = false;
@@ -1563,6 +1583,21 @@ public class MainWindowViewModel : ViewModelBase
 
     public Visibility AssistTeamPanelVisibility =>
         IsAssistTeamSelectionActive ? Visibility.Visible : Visibility.Collapsed;
+
+    private bool _isFreeThrowTeamSelectionActive;
+    public bool IsFreeThrowTeamSelectionActive
+    {
+        get => _isFreeThrowTeamSelectionActive;
+        set
+        {
+            _isFreeThrowTeamSelectionActive = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(FreeThrowTeamPanelVisibility));
+        }
+    }
+
+    public Visibility FreeThrowTeamPanelVisibility =>
+        IsFreeThrowTeamSelectionActive ? Visibility.Visible : Visibility.Collapsed;
 
     private void UpdateAssistPlayerStyles()
     {


### PR DESCRIPTION
## Summary
- add commands to pick free-throw team
- track whether the free-throw team panel is visible
- show free throw team selection screen before choosing shots

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871225424608326a7fcdc22c7645bee