### PR TITLE
Enable manual clock adjustments

### DIFF
--- a/StatsBB/Services/GameClockService.cs
+++ b/StatsBB/Services/GameClockService.cs
@@ -6,6 +6,7 @@ namespace StatsBB.Services;
 public static class GameClockService
 {
     private static readonly DispatcherTimer _timer;
+    private static TimeSpan _maxTime = TimeSpan.FromMinutes(10);
 
     static GameClockService()
     {
@@ -95,10 +96,26 @@ public static class GameClockService
             Start();
     }
 
+    private static void AddTime(TimeSpan delta)
+    {
+        TimeLeft += delta;
+        if (TimeLeft < TimeSpan.Zero)
+            TimeLeft = TimeSpan.Zero;
+        if (TimeLeft > _maxTime)
+            TimeLeft = _maxTime;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void AddMinute() => AddTime(TimeSpan.FromMinutes(1));
+    public static void SubtractMinute() => AddTime(TimeSpan.FromMinutes(-1));
+    public static void AddSecond() => AddTime(TimeSpan.FromSeconds(1));
+    public static void SubtractSecond() => AddTime(TimeSpan.FromSeconds(-1));
+
     public static void Reset(TimeSpan? periodLength = null, string? periodName = null, string? label = "START")
     {
         Period = periodName ?? "Q1";
-        TimeLeft = periodLength ?? TimeSpan.FromMinutes(10);
+        _maxTime = periodLength ?? TimeSpan.FromMinutes(10);
+        TimeLeft = _maxTime;
         StartStopLabel = label ?? "START";
         StartStopEnabled = true;
         TimeUpdated?.Invoke();

--- a/StatsBB/UserControls/GameClock.xaml
+++ b/StatsBB/UserControls/GameClock.xaml
@@ -16,15 +16,15 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0" Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Button Content="▲" Width="25" Height="25" Background="White" BorderThickness="0" />
-                    <Button Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" />
+                    <Button x:Name="AddMinuteButton" Content="▲" Width="25" Height="25" Background="White" BorderThickness="0" Click="AddMinute_Click" />
+                    <Button x:Name="SubtractMinuteButton" Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" Click="SubtractMinute_Click" />
                 </StackPanel>
                 <Border Grid.Column="1" Padding="0" Margin="0,0">
                     <TextBlock x:Name="TimeText" Text="10:00" Foreground="black" FontSize="36" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Border>
                 <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left">
-                    <Button Content="▲" Width="25" Height="25" Background="White" BorderThickness="0" />
-                    <Button Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" />
+                    <Button x:Name="AddSecondButton" Content="▲" Width="25" Height="25" Background="White" BorderThickness="0" Click="AddSecond_Click" />
+                    <Button x:Name="SubtractSecondButton" Content="▼" Width="25" Height="25" Background="White" BorderThickness="0" Click="SubtractSecond_Click" />
                 </StackPanel>
                 <Button x:Name="StartStopButton" Grid.Column="3" Content="STOP" Width="70" Height="50" Background="Green" Foreground="White" FontWeight="Bold" VerticalAlignment="Center" Margin="10,0,0,0" Click="StartStop_Click"/>
             </Grid>

--- a/StatsBB/UserControls/GameClock.xaml.cs
+++ b/StatsBB/UserControls/GameClock.xaml.cs
@@ -20,6 +20,11 @@ public partial class GameClock : UserControl
         UpdateDisplay();
     }
 
+    private void AddMinute_Click(object sender, RoutedEventArgs e) => GameClockService.AddMinute();
+    private void SubtractMinute_Click(object sender, RoutedEventArgs e) => GameClockService.SubtractMinute();
+    private void AddSecond_Click(object sender, RoutedEventArgs e) => GameClockService.AddSecond();
+    private void SubtractSecond_Click(object sender, RoutedEventArgs e) => GameClockService.SubtractSecond();
+
     private void UpdateDisplay()
     {
         TimeText.Text = GameClockService.TimeLeftString;


### PR DESCRIPTION
## Summary
- allow editing the game clock by seconds and minutes
- wire up arrow buttons in `GameClock` control
- keep time value within bounds of each period

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687123d58da48326b909dcdf28dfc985