### PR TITLE
Add dynamic period results

### DIFF
--- a/StatsBB/UserControls/StatsView.xaml
+++ b/StatsBB/UserControls/StatsView.xaml
@@ -26,14 +26,23 @@
             <TextBlock Text="-" Grid.Column="2" Grid.Row="0" FontWeight="Bold" VerticalAlignment="Bottom" FontSize="48" Margin="10"/>
             <TextBlock Text="{Binding AwayScore}" Grid.Row="0" Grid.Column="3" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="10" FontWeight="Bold" FontSize="48" />
             <TextBlock Text="{Binding AwayTeamName}" Grid.Row="0" Grid.Column="4" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="10" FontWeight="Bold" FontSize="32"/>
-            <Border  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3">
-                <StackPanel x:Name="PeriodResults" Orientation="Horizontal">
-                    <StackPanel Orientation="Horizontal" Margin="2">
-                        <TextBlock Style="{StaticResource PeriodResult}" Text="0"/>
-                        <TextBlock Style="{StaticResource PeriodResult}" Text=" : "/>
-                        <TextBlock Style="{StaticResource PeriodResult}" Text="0"/>
-                    </StackPanel>
-                </StackPanel>
+            <Border Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3">
+                <ItemsControl x:Name="PeriodResults" ItemsSource="{Binding PeriodResults}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" Margin="2">
+                                <TextBlock Style="{StaticResource PeriodResult}" Text="{Binding HomePeriodScore}" />
+                                <TextBlock Style="{StaticResource PeriodResult}" Text=" : " />
+                                <TextBlock Style="{StaticResource PeriodResult}" Text="{Binding AwayPeriodScore}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </Border>
         </Grid>
         <StackPanel Width="1070">

--- a/StatsBB/ViewModel/StatsTabViewModel.cs
+++ b/StatsBB/ViewModel/StatsTabViewModel.cs
@@ -46,6 +46,8 @@ public class StatsTabViewModel : ViewModelBase
     public int AwayP3 => GetAwayPeriod(2);
     public int AwayP4 => GetAwayPeriod(3);
 
+    public ObservableCollection<Period> PeriodResults => new(Game.Periods);
+
     private Player CalculateTotals(bool home)
     {
         var players = home
@@ -136,5 +138,6 @@ public class StatsTabViewModel : ViewModelBase
         OnPropertyChanged(nameof(AwayTotalsCollection));
         OnPropertyChanged(nameof(HomeTeamStatsCollection));
         OnPropertyChanged(nameof(AwayTeamStatsCollection));
+        OnPropertyChanged(nameof(PeriodResults));
     }
 }


### PR DESCRIPTION
## Summary
- allow StatsTabViewModel to expose period results list
- update refresh logic
- show period results using ItemsControl in StatsView

## Testing
- `dotnet build StatsBB/StatsBB.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871249b8108832694a5820d107b4d82