### PR TITLE
Add period to play card header

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -2420,6 +2420,7 @@ public class MainWindowViewModel : ViewModelBase
     private void AddPlayCard(IEnumerable<PlayActionViewModel> actions)
     {
         PlayLog.AddCard(
+            Game.GetCurrentPeriod().Name,
             GameClockService.TimeLeftString,
             GameState.TeamAScore,
             GameState.TeamBScore,

--- a/StatsBB/ViewModel/PlayByPlayLogModels.cs
+++ b/StatsBB/ViewModel/PlayByPlayLogModels.cs
@@ -14,10 +14,18 @@ public class PlayActionViewModel
 
 public class PlayCardViewModel
 {
+    /// <summary>
+    /// Name of the period when the actions occurred (e.g. "Q1").
+    /// </summary>
+    public string PeriodName { get; set; } = string.Empty;
     public string Time { get; set; } = string.Empty;
     public int TeamAScore { get; set; }
     public int TeamBScore { get; set; }
     public ObservableCollection<PlayActionViewModel> Actions { get; } = new();
 
-    public string Header => $"{Time} {TeamAScore}:{TeamBScore}";
+    /// <summary>
+    /// Header displayed above play actions.
+    /// Formatted as "PERIOD TIME SCORE" (e.g. "Q1 09:58 10:8").
+    /// </summary>
+    public string Header => $"{PeriodName} {Time} {TeamAScore}:{TeamBScore}";
 }

--- a/StatsBB/ViewModel/PlayByPlayLogViewModel.cs
+++ b/StatsBB/ViewModel/PlayByPlayLogViewModel.cs
@@ -14,15 +14,17 @@ public class PlayByPlayLogViewModel : ViewModelBase
     /// <summary>
     /// Adds a new play card to the log.
     /// </summary>
+    /// <param name="period">Name of the period when the play happened.</param>
     /// <param name="time">Timestamp of the play.</param>
     /// <param name="teamAScore">Current home score.</param>
     /// <param name="teamBScore">Current away score.</param>
     /// <param name="actions">Actions to display on the card.</param>
-    public void AddCard(string time, int teamAScore, int teamBScore,
+    public void AddCard(string period, string time, int teamAScore, int teamBScore,
         IEnumerable<PlayActionViewModel> actions)
     {
         var card = new PlayCardViewModel
         {
+            PeriodName = period,
             Time = time,
             TeamAScore = teamAScore,
             TeamBScore = teamBScore


### PR DESCRIPTION
## Summary
- include period name on each PlayCardViewModel
- show period when adding cards to play log
- display header as "PERIOD TIME SCORE"

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712535d28483268472c968423a4176