### PR TITLE
Fix action button availability with open panels

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1812,18 +1812,18 @@ Margin="4" />
                     </Border>
                     <Border Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="3" BorderThickness="2" BorderBrush="#888" VerticalAlignment="Top" HorizontalAlignment="Stretch" Padding="5" Margin="0,10">
                         <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5" Width="1000">
-                        <Button Content="MADE" Style="{StaticResource Made}" Command="{Binding SelectActionCommand}" CommandParameter="MADE" IsEnabled="{Binding IsActionSelectionActive}"/>
-                        <Button Content="MISSED" Style="{StaticResource Missed}" Command="{Binding SelectActionCommand}" CommandParameter="Missed" IsEnabled="{Binding IsActionSelectionActive}"/>
-                        <Button Content="FOUL (E)" Style="{StaticResource Foul}" Command="{Binding SelectActionCommand}" CommandParameter="Foul"/>
-                        <Button Content="TURNOVER (R)" Style="{StaticResource Turnover}" Command="{Binding StartTurnoverCommand}"/>
-                        <Button Content="TIME OUT" Style="{StaticResource TimeOut}" Command="{Binding StartTimeoutCommand}"/>
-                        <Button Content="JUMP BALL" Style="{StaticResource JumpBall}" Command="{Binding StartJumpBallCommand}"/>
-                        <Button Content="SUBSTITUTIONS" Style="{StaticResource Sub}" Command="{Binding StartSubstitutionCommand}"/>
-                        <Button Content="S5" Style="{StaticResource Sub}" Command="{Binding StartStartingFiveCommand}"/>
-                        <Button Content="FREE THROWS" Style="{StaticResource FreeThrows}" Command="{Binding StartFreeThrowsCommand}"/>
-                        <Button Content="ASSIST" Style="{StaticResource Assist}" Command="{Binding StartAssistCommand}"/>
-                        <Button Content="REBOUND" Style="{StaticResource Rebound}" Command="{Binding StartReboundCommand}"/>
-                        <Button Content="STEAL" Style="{StaticResource Steal}" Command="{Binding StartStealCommand}"/>
+                        <Button Content="MADE" Style="{StaticResource Made}" Command="{Binding SelectActionCommand}" CommandParameter="MADE" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="MISSED" Style="{StaticResource Missed}" Command="{Binding SelectActionCommand}" CommandParameter="Missed" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="FOUL (E)" Style="{StaticResource Foul}" Command="{Binding SelectActionCommand}" CommandParameter="Foul" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="TURNOVER (R)" Style="{StaticResource Turnover}" Command="{Binding StartTurnoverCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="TIME OUT" Style="{StaticResource TimeOut}" Command="{Binding StartTimeoutCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="JUMP BALL" Style="{StaticResource JumpBall}" Command="{Binding StartJumpBallCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="SUBSTITUTIONS" Style="{StaticResource Sub}" Command="{Binding StartSubstitutionCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="S5" Style="{StaticResource Sub}" Command="{Binding StartStartingFiveCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="FREE THROWS" Style="{StaticResource FreeThrows}" Command="{Binding StartFreeThrowsCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="ASSIST" Style="{StaticResource Assist}" Command="{Binding StartAssistCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="REBOUND" Style="{StaticResource Rebound}" Command="{Binding StartReboundCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
+                        <Button Content="STEAL" Style="{StaticResource Steal}" Command="{Binding StartStealCommand}" IsEnabled="{Binding AreActionButtonsEnabled}"/>
                     </WrapPanel>
                     </Border>
                 </Grid>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -203,6 +203,7 @@ public class MainWindowViewModel : ViewModelBase
             _isSubstitutionPanelVisible = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(SubstitutionPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility SubstitutionPanelVisibility =>
@@ -217,6 +218,7 @@ public class MainWindowViewModel : ViewModelBase
             _isTimeOutSelectionActive = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(TimeOutPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility TimeOutPanelVisibility =>
@@ -231,6 +233,7 @@ public class MainWindowViewModel : ViewModelBase
             _isStartingFivePanelVisible = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(StartingFivePanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility StartingFivePanelVisibility =>
@@ -246,12 +249,37 @@ public class MainWindowViewModel : ViewModelBase
             _isGamePanelVisible = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(GamePanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility GamePanelVisibility =>
         IsGamePanelVisible ? Visibility.Visible : Visibility.Collapsed;
 
     public bool AreTeamsConfirmed => TeamInfoVM.AreTeamsConfirmed;
+
+    public bool IsAnyActionPanelVisible =>
+        IsSubstitutionPanelVisible ||
+        IsTimeOutSelectionActive ||
+        IsStartingFivePanelVisible ||
+        IsGamePanelVisible ||
+        IsJumpBallPanelVisible ||
+        IsJumpWinnerPanelVisible ||
+        IsAssistTeamSelectionActive ||
+        IsAssistSelectionActive ||
+        IsReboundSelectionActive ||
+        IsReboundTypeSelectionActive ||
+        IsBlockerSelectionActive ||
+        IsTurnoverSelectionActive ||
+        IsStealSelectionActive ||
+        IsStealTeamSelectionActive ||
+        IsQuickShotSelectionActive ||
+        IsFoulCommiterSelectionActive ||
+        IsFoulTypeSelectionActive ||
+        IsFouledPlayerSelectionActive ||
+        IsFreeThrowsAwardedSelectionActive ||
+        IsFreeThrowsSelectionActive;
+
+    public bool AreActionButtonsEnabled => IsActionSelectionActive && !IsAnyActionPanelVisible;
     
     private bool _isJumpBallPanelVisible;
     public bool IsJumpBallPanelVisible
@@ -262,6 +290,7 @@ public class MainWindowViewModel : ViewModelBase
             _isJumpBallPanelVisible = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(JumpBallPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility JumpBallPanelVisibility =>
@@ -276,6 +305,7 @@ public class MainWindowViewModel : ViewModelBase
             _isJumpWinnerPanelVisible = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(JumpWinnerPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     public Visibility JumpWinnerPanelVisibility =>
@@ -1577,6 +1607,7 @@ public class MainWindowViewModel : ViewModelBase
             _isAssistTeamSelectionActive = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(AssistTeamPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1590,6 +1621,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateAssistPlayerStyles();
             OnPropertyChanged(nameof(NoAssistButtonVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1659,6 +1691,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateReboundPlayerStyles();
             OnPropertyChanged(nameof(ReboundPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
     private void UpdateReboundPlayerStyles()
@@ -1717,6 +1750,7 @@ public class MainWindowViewModel : ViewModelBase
             _isReboundTypeSelectionActive = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(ReboundTypePanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1733,6 +1767,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateBlockerPlayerStyles();
             OnPropertyChanged(nameof(BlockerSelectionVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1749,6 +1784,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateTurnoverPlayerStyles();
             OnPropertyChanged(nameof(TurnoverPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1765,6 +1801,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateStealPlayerStyles();
             OnPropertyChanged(nameof(StealPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1780,6 +1817,7 @@ public class MainWindowViewModel : ViewModelBase
             _isStealTeamSelectionActive = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(StealTeamPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1796,6 +1834,7 @@ public class MainWindowViewModel : ViewModelBase
             OnPropertyChanged();
             UpdateQuickShotPlayerStyles();
             OnPropertyChanged(nameof(QuickShotPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1892,6 +1931,7 @@ public class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(EligibleTeamBCourtFoulCommitterPlayers));
                 OnPropertyChanged(nameof(EligibleTeamBBenchFoulCommitterPlayers));
             }
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1907,6 +1947,7 @@ public class MainWindowViewModel : ViewModelBase
             _isFoulTypeSelectionActive = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(FoulTypePanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1926,6 +1967,7 @@ public class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(EligibleFoulOnCourtPlayers));
                 OnPropertyChanged(nameof(EligibleFoulOnBenchPlayers));
             }
+            NotifyPanelStateChanged();
         }
     }
 
@@ -1940,6 +1982,7 @@ public class MainWindowViewModel : ViewModelBase
             if (value)
                 UpdateFreeThrowPlayerStyles();
             OnPropertyChanged(nameof(FreeThrowsAwardedPanelVisibility));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -2007,6 +2050,7 @@ public class MainWindowViewModel : ViewModelBase
                 UpdateFreeThrowPlayerStyles();
             OnPropertyChanged(nameof(FreeThrowsPanelVisibility));
             OnPropertyChanged(nameof(FreeThrowResultRows));
+            NotifyPanelStateChanged();
         }
     }
 
@@ -2143,6 +2187,13 @@ public class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(FreeThrowCount3Style));
     }
 
+    private void NotifyPanelStateChanged()
+    {
+        OnPropertyChanged(nameof(IsAnyActionPanelVisible));
+        OnPropertyChanged(nameof(AreActionButtonsEnabled));
+        UpdateActionButtonStyles();
+    }
+
 
 
     // Action button styles
@@ -2157,7 +2208,7 @@ public class MainWindowViewModel : ViewModelBase
 
     private Style GetActionStyle(string action)
     {
-        if (!IsActionSelectionActive && action != "FOUL")
+        if ((!IsActionSelectionActive || IsAnyActionPanelVisible) && action != "FOUL")
             return (Style)_resources["ActionDisabledButtonStyle"];
 
         if (SelectedAction == action)


### PR DESCRIPTION
## Summary
- disable all action buttons whenever any action panel is visible
- add binding and state helper for action button availability

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68712578c9b48326afa8da576397f727