### PR TITLE
Implement final game tab behavior

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -398,12 +398,12 @@
                 Command="{Binding StartTurnoverCommand}" />
     </Window.InputBindings>
 
-    <TabControl>
-        <TabItem Header="TEAM INFO">
+    <TabControl SelectedIndex="{Binding SelectedTabIndex}">
+        <TabItem Header="TEAM INFO" IsEnabled="{Binding IsTeamInfoEnabled}">
 
             <controls:TeamInfoView DataContext="{Binding TeamInfoVM}" />
         </TabItem>
-        <TabItem Header="MAIN" IsEnabled="{Binding AreTeamsConfirmed}">
+        <TabItem Header="MAIN" IsEnabled="{Binding IsMainTabEnabled}">
             <Grid x:Name="___No_Name_" Background="#F9F9F9">
                 <!-- Layout: Header, Event Buttons, Main Content -->
                 <Grid.RowDefinitions>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -252,6 +252,39 @@ public class MainWindowViewModel : ViewModelBase
         IsGamePanelVisible ? Visibility.Visible : Visibility.Collapsed;
 
     public bool AreTeamsConfirmed => TeamInfoVM.AreTeamsConfirmed;
+
+    private bool _isGameFinalized;
+    public bool IsGameFinalized
+    {
+        get => _isGameFinalized;
+        set
+        {
+            if (_isGameFinalized == value)
+                return;
+
+            _isGameFinalized = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsTeamInfoEnabled));
+            OnPropertyChanged(nameof(IsMainTabEnabled));
+        }
+    }
+
+    public bool IsTeamInfoEnabled => !IsGameFinalized;
+    public bool IsMainTabEnabled => AreTeamsConfirmed && !IsGameFinalized;
+
+    private int _selectedTabIndex;
+    public int SelectedTabIndex
+    {
+        get => _selectedTabIndex;
+        set
+        {
+            if (_selectedTabIndex == value)
+                return;
+
+            _selectedTabIndex = value;
+            OnPropertyChanged();
+        }
+    }
     
     private bool _isJumpBallPanelVisible;
     public bool IsJumpBallPanelVisible
@@ -345,6 +378,7 @@ public class MainWindowViewModel : ViewModelBase
         _resources = resources;
         TeamInfoVM = new TeamInfoViewModel(this);
         ScoreBoardVM = new ScoreBoardViewModel(this);
+        SelectedTabIndex = 0;
 
         StartSubstitutionCommand = new RelayCommand(_ => BeginSubstitution());
 
@@ -480,7 +514,10 @@ public class MainWindowViewModel : ViewModelBase
         TeamInfoVM.PropertyChanged += (s, e) =>
         {
             if (e.PropertyName == nameof(TeamInfoViewModel.AreTeamsConfirmed))
+            {
                 OnPropertyChanged(nameof(AreTeamsConfirmed));
+                OnPropertyChanged(nameof(IsMainTabEnabled));
+            }
         };
 
         Game.HomeTeam.Players.CollectionChanged += TeamPlayersChanged;
@@ -552,6 +589,8 @@ public class MainWindowViewModel : ViewModelBase
     private void OnFinalizeGameRequested()
     {
         GameClockService.SetState("FINALIZED", false);
+        IsGameFinalized = true;
+        SelectedTabIndex = 2; // switch to Stats tab
     }
 
     private void BeginTimeout()


### PR DESCRIPTION
## Summary
- disable Team Info and Main tabs when the game is finalized
- switch to the Stats tab on finalization
- track selected tab and game final state in `MainWindowViewModel`

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687125b205d883268674ae017408212e