### PR TITLE
Fix OT finalize and update timer label

### DIFF
--- a/StatsBB/Services/GameClockService.cs
+++ b/StatsBB/Services/GameClockService.cs
@@ -103,6 +103,11 @@ public static class GameClockService
             TimeLeft = TimeSpan.Zero;
         if (TimeLeft > _maxTime)
             TimeLeft = _maxTime;
+        if (TimeLeft > TimeSpan.Zero && (StartStopLabel == "END PERIOD" || StartStopLabel == "FINALIZE GAME"))
+        {
+            StartStopLabel = "START";
+            StartStopEnabled = true;
+        }
         TimeUpdated?.Invoke();
     }
 

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -568,8 +568,9 @@ public class MainWindowViewModel : ViewModelBase
         period.Status = PeriodStatus.Ended;
 
         bool lastRegular = period.IsRegular && period.PeriodNumber == Game.DefaultPeriods;
+        bool overtime = !period.IsRegular;
 
-        if (lastRegular && Game.HomeTeam.Points != Game.AwayTeam.Points)
+        if ((lastRegular || overtime) && Game.HomeTeam.Points != Game.AwayTeam.Points)
         {
             GameClockService.SetState("FINALIZE GAME", true);
             return;


### PR DESCRIPTION
## Summary
- handle overtime finals the same as the last regular period
- reset Start/Stop button when time is changed from 0

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687131bf1f108326a06a2461ab5101ba