### PR TITLE
Add team confirmation indicators

### DIFF
--- a/StatsBB/UserControls/TeamInfoView.xaml
+++ b/StatsBB/UserControls/TeamInfoView.xaml
@@ -5,6 +5,7 @@
     <UserControl.Resources>
         <converters:ColorAvailabilityConverter x:Key="ColorAvailabilityConverter"/>
         <converters:ColorSelectedConverter x:Key="ColorSelectedConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <Style x:Key="TeamColorButtonStyle" TargetType="RadioButton">
             <Setter Property="Width" Value="50"/>
             <Setter Property="Height" Value="50"/>


### PR DESCRIPTION
## Summary
- show a green check mark when teams are confirmed
- disable confirm button once selected

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713581e06083269cf6e08dfbd7de18