### PR TITLE
Remove row selection from TeamInfoView

### DIFF
--- a/StatsBB/UserControls/TeamInfoView.xaml.cs
+++ b/StatsBB/UserControls/TeamInfoView.xaml.cs
@@ -39,7 +39,6 @@ public partial class TeamInfoView : UserControl
             if (r < 0 || r >= grid.Items.Count || c < 0 || c >= grid.Columns.Count)
                 return;
             grid.CommitEdit(DataGridEditingUnit.Cell, true);
-            grid.SelectedIndex = r;
             grid.CurrentCell = new DataGridCellInfo(grid.Items[r], grid.Columns[c]);
             grid.ScrollIntoView(grid.Items[r]);
             grid.BeginEdit();


### PR DESCRIPTION
## Summary
- prevent selecting entire row when navigating DataGrid cells

## Testing
- `dotnet build StatsBB.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687139635d808326b9851fe7d74af6b5