### PR TITLE
Fix assist selection usability in free throws

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -2205,9 +2205,9 @@ public class MainWindowViewModel : ViewModelBase
             FreeThrowResultRows.Add(item);
         }
 
-        UpdateAssistPlayerStyles();
-
         IsFreeThrowsSelectionActive = true;
+
+        UpdateAssistPlayerStyles();
     }
 
     private void OnFreeThrowResultSelected(int index, string result)


### PR DESCRIPTION
## Summary
- fix assist selection logic in free throw panel so assist players are enabled immediately when the panel opens

## Testing
- `dotnet build StatsBB.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713b84c0408326b684b62550029c79