### PR TITLE
Update players when confirming teams

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -847,7 +847,7 @@ public class MainWindowViewModel : ViewModelBase
     }
 
 
-    private void RegenerateTeamsFromInfo()
+    public void RegenerateTeamsFromInfo()
     {
         Players.Clear();
 

--- a/StatsBB/ViewModel/TeamInfoViewModel.cs
+++ b/StatsBB/ViewModel/TeamInfoViewModel.cs
@@ -67,8 +67,16 @@ public class TeamInfoViewModel : ViewModelBase
         SaveHomeTeamCommand = new RelayCommand(_ => SaveTeam(Game.HomeTeam));
         LoadAwayTeamCommand = new RelayCommand(_ => LoadTeam(Game.AwayTeam, false));
         SaveAwayTeamCommand = new RelayCommand(_ => SaveTeam(Game.AwayTeam));
-        ConfirmHomeTeamCommand = new RelayCommand(_ => HomeTeamConfirmed = true);
-        ConfirmAwayTeamCommand = new RelayCommand(_ => AwayTeamConfirmed = true);
+        ConfirmHomeTeamCommand = new RelayCommand(_ =>
+        {
+            HomeTeamConfirmed = true;
+            _main.RegenerateTeamsFromInfo();
+        });
+        ConfirmAwayTeamCommand = new RelayCommand(_ =>
+        {
+            AwayTeamConfirmed = true;
+            _main.RegenerateTeamsFromInfo();
+        });
     }
 
     private static void EnsurePlayers(Team team)


### PR DESCRIPTION
## Summary
- regenerate player lists whenever a team is confirmed
- expose `RegenerateTeamsFromInfo` so other view models can call it

## Testing
- `dotnet build StatsBB.sln -clp:ErrorsOnly` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713b266e648326bd62b3bcd1858ef6