### PR TITLE
Integrate Material Design theme

### DIFF
--- a/StatsBB/App.xaml
+++ b/StatsBB/App.xaml
@@ -1,9 +1,21 @@
-﻿<Application x:Class="StatsBB.App"
+<Application x:Class="StatsBB.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:StatsBB"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <materialDesign:BundledTheme BaseTheme="Light"
+                                              PrimaryColor="DeepPurple"
+                                              SecondaryColor="Lime" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Default.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Apply Material Design to all buttons -->
+            <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignRaisedButton}" />
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1,10 +1,11 @@
-﻿<Window x:Class="StatsBB.MainWindow"
+<Window x:Class="StatsBB.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:StatsBB.UserControls" 
-        xmlns:viewmodel="clr-namespace:StatsBB.ViewModel" 
+        xmlns:controls="clr-namespace:StatsBB.UserControls"
+        xmlns:viewmodel="clr-namespace:StatsBB.ViewModel"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:converters="clr-namespace:StatsBB.Converters"
         xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         Title="Basketball Stats Map" Height="1080" Width="1920"
         PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
@@ -426,7 +427,7 @@
                 Command="{Binding StartStealCommand}" />
     </Window.InputBindings>
 
-    <TabControl SelectedIndex="{Binding SelectedTabIndex}">
+    <TabControl SelectedIndex="{Binding SelectedTabIndex}" Style="{StaticResource MaterialDesignTabControl}">
         <TabItem Header="TEAM INFO" IsEnabled="{Binding IsTeamInfoEnabled}">
 
             <controls:TeamInfoView DataContext="{Binding TeamInfoVM}" />

--- a/StatsBB/StatsBB.csproj
+++ b/StatsBB/StatsBB.csproj
@@ -10,4 +10,9 @@
     <FileVersion>0.6.8</FileVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignThemes" Version="5.2.0" />
+    <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add MaterialDesign packages
- apply Material Design theme in App.xaml
- enable Material Design tab control styling

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e48d76d48326b00c4b60150f23ae