### PR TITLE
Add possession tracking

### DIFF
--- a/StatsBB/Services/GameClockService.cs
+++ b/StatsBB/Services/GameClockService.cs
@@ -18,6 +18,9 @@ public static class GameClockService
     public static string Period { get; private set; } = "Q1";
     public static bool IsRunning => _timer.IsEnabled;
 
+    public static bool TeamAPossession { get; private set; } = true;
+    public static bool TeamAArrow { get; private set; } = true;
+
     public static string StartStopLabel { get; private set; } = "START";
     public static bool StartStopEnabled { get; private set; } = true;
 
@@ -133,6 +136,37 @@ public static class GameClockService
         TimeLeft = _maxTime;
         StartStopLabel = label ?? "START";
         StartStopEnabled = true;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void SetPossession(bool teamA)
+    {
+        TeamAPossession = teamA;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void SwapPossession()
+    {
+        TeamAPossession = !TeamAPossession;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void SetArrow(bool teamA)
+    {
+        TeamAArrow = teamA;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void SwapArrow()
+    {
+        TeamAArrow = !TeamAArrow;
+        TimeUpdated?.Invoke();
+    }
+
+    public static void SwapPossessionAndArrow()
+    {
+        TeamAPossession = !TeamAPossession;
+        TeamAArrow = !TeamAArrow;
         TimeUpdated?.Invoke();
     }
 

--- a/StatsBB/UserControls/GameClock.xaml
+++ b/StatsBB/UserControls/GameClock.xaml
@@ -7,7 +7,22 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <TextBlock x:Name="PeriodText" Grid.Row="0" Text="Q1 - In Progress" Foreground="Black" FontWeight="Bold" FontSize="16" HorizontalAlignment="Center" Margin="5" />
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="20"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="20"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Left">
+                    <TextBlock x:Name="ArrowAText" Text="←" FontSize="14" Visibility="Collapsed"/>
+                    <TextBlock x:Name="PossessionAText" Text="●" FontSize="14" Visibility="Collapsed"/>
+                </StackPanel>
+                <TextBlock x:Name="PeriodText" Grid.Column="1" Text="Q1 - In Progress" Foreground="Black" FontWeight="Bold" FontSize="16" HorizontalAlignment="Center" Margin="5" />
+                <StackPanel Grid.Column="2" Orientation="Vertical" HorizontalAlignment="Right">
+                    <TextBlock x:Name="ArrowBText" Text="→" FontSize="14" Visibility="Collapsed"/>
+                    <TextBlock x:Name="PossessionBText" Text="●" FontSize="14" Visibility="Collapsed"/>
+                </StackPanel>
+            </Grid>
             <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>

--- a/StatsBB/UserControls/GameClock.xaml.cs
+++ b/StatsBB/UserControls/GameClock.xaml.cs
@@ -34,6 +34,11 @@ public partial class GameClock : UserControl
         StartStopButton.Background = GameClockService.IsRunning
             ? Brushes.Green
             : GameClockService.StartStopEnabled ? Brushes.Red : Brushes.LightGray;
+
+        ArrowAText.Visibility = GameClockService.TeamAArrow ? Visibility.Visible : Visibility.Collapsed;
+        ArrowBText.Visibility = GameClockService.TeamAArrow ? Visibility.Collapsed : Visibility.Visible;
+        PossessionAText.Visibility = GameClockService.TeamAPossession ? Visibility.Visible : Visibility.Collapsed;
+        PossessionBText.Visibility = GameClockService.TeamAPossession ? Visibility.Collapsed : Visibility.Visible;
     }
 
     public void Toggle() => StartStop_Click(this, new RoutedEventArgs());

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -387,6 +387,9 @@ public class MainWindowViewModel : ViewModelBase
     public ICommand SelectFreeThrowAssistCommand { get; }
     public ICommand NoAssistFreeThrowCommand { get; }
     public ICommand SwapSidesCommand { get; }
+    public ICommand SwapPossessionCommand { get; }
+    public ICommand SwapArrowCommand { get; }
+    public ICommand SwapPossessionArrowCommand { get; }
 
 
     public event Action<Point, Brush, bool>? MarkerRequested;
@@ -479,6 +482,9 @@ public class MainWindowViewModel : ViewModelBase
         NoAssistFreeThrowCommand = new RelayCommand(_ => SetNoFreeThrowAssist());
 
         SwapSidesCommand = new RelayCommand(_ => SwapSides());
+        SwapPossessionCommand = new RelayCommand(_ => GameClockService.SwapPossession());
+        SwapArrowCommand = new RelayCommand(_ => GameClockService.SwapArrow());
+        SwapPossessionArrowCommand = new RelayCommand(_ => GameClockService.SwapPossessionAndArrow());
 
         SelectTeamAColorCommand = new RelayCommand(p =>
         {


### PR DESCRIPTION
## Summary
- track possession and possession arrow in `GameClockService`
- expose commands in `MainWindowViewModel` to swap possession/arrow
- display indicators of possession and possession arrow on the GameClock

## Testing
- `dotnet build StatsBB/StatsBB.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7b03c5c08326b0e7c4bd09c12121