### PR TITLE
Fix double personal foul handling

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -961,23 +961,47 @@ public class MainWindowViewModel : ViewModelBase
             _fouledPlayer = player;
             IsFouledPlayerSelectionActive = false;
 
-            if (_fouledPlayer != null)
-                _currentPlayActions.Add(CreateAction(_fouledPlayer, "FOULED"));
-
-            if (_foulCommiter != null)
-                GameState.AddFoul(_foulCommiter.IsTeamA);
-
-            AddPlayCard(_currentPlayActions.ToList());
-            _currentPlayActions.Clear();
-
-            if (_foulType?.ToLowerInvariant() == "offensive")
+            if (_foulType?.ToLowerInvariant() == "double personal")
             {
-                Debug.WriteLine($"{GameClockService.TimeLeftString} Offensive foul by {_foulCommiter?.Number}.{_foulCommiter?.Name} on {_fouledPlayer?.Number}.{_fouledPlayer?.Name} — no free throws");
+                if (_fouledPlayer != null)
+                    _currentPlayActions.Add(CreateAction(_fouledPlayer, $"FOUL {_foulType.ToUpperInvariant()}"));
+
+                if (_foulCommiter != null)
+                {
+                    GameState.AddFoul(_foulCommiter.IsTeamA);
+                    _actionProcessor.Process(ActionType.Foul, _foulCommiter);
+                }
+                if (_fouledPlayer != null)
+                {
+                    GameState.AddFoul(_fouledPlayer.IsTeamA);
+                    _actionProcessor.Process(ActionType.Foul, _fouledPlayer);
+                }
+
+                AddPlayCard(_currentPlayActions.ToList());
+                _currentPlayActions.Clear();
+                StatsVM.Refresh();
                 ResetFoulState();
             }
             else
             {
-                BeginFreeThrowsAwardedSelection();
+                if (_fouledPlayer != null)
+                    _currentPlayActions.Add(CreateAction(_fouledPlayer, "FOULED"));
+
+                if (_foulCommiter != null)
+                    GameState.AddFoul(_foulCommiter.IsTeamA);
+
+                AddPlayCard(_currentPlayActions.ToList());
+                _currentPlayActions.Clear();
+
+                if (_foulType?.ToLowerInvariant() == "offensive")
+                {
+                    Debug.WriteLine($"{GameClockService.TimeLeftString} Offensive foul by {_foulCommiter?.Number}.{_foulCommiter?.Name} on {_fouledPlayer?.Number}.{_fouledPlayer?.Name} — no free throws");
+                    ResetFoulState();
+                }
+                else
+                {
+                    BeginFreeThrowsAwardedSelection();
+                }
             }
 
             return;


### PR DESCRIPTION
## Summary
- foul commit and fouled player selections previously handled all fouls identically
- add special logic so selecting a second player on a *double personal* foul
  adds a foul to **both** players and teams

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7c7c586c83268cb36d28b7267f62