### PR TITLE
Add play-by-play start/end actions

### DIFF
--- a/StatsBB/Model/PlayByPlay.cs
+++ b/StatsBB/Model/PlayByPlay.cs
@@ -43,6 +43,8 @@
         SubstitutionOut = 26,
         Dunk = 27,
         Putback = 28,
-        Unknown = 29
+        Unknown = 29,
+        HalfStart = 30,
+        HalfEnd = 31
     }
 }

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -590,10 +590,10 @@ public class MainWindowViewModel : ViewModelBase
 
         var endActions = new List<PlayActionViewModel>
         {
-            CreateGameAction("PERIOD END")
+            CreateGameAction(PlayType.PeriodEnd)
         };
         if (period.IsRegular && (period.PeriodNumber == 2 || period.PeriodNumber == Game.DefaultPeriods))
-            endActions.Add(CreateGameAction("HALF END"));
+            endActions.Add(CreateGameAction(PlayType.HalfEnd));
         AddPlayCard(endActions);
 
         bool lastRegular = period.IsRegular && period.PeriodNumber == Game.DefaultPeriods;
@@ -622,7 +622,7 @@ public class MainWindowViewModel : ViewModelBase
 
     private void OnFinalizeGameRequested()
     {
-        AddPlayCard(new[] { CreateGameAction("GAME END") });
+        AddPlayCard(new[] { CreateGameAction(PlayType.GameEnd) });
         GameClockService.SetState("FINALIZED", false);
         IsGameFinalized = true;
         SelectedTabIndex = 2; // switch to Stats tab
@@ -638,14 +638,14 @@ public class MainWindowViewModel : ViewModelBase
             var startActions = new List<PlayActionViewModel>();
             if (period.PeriodNumber == 1)
             {
-                startActions.Add(CreateGameAction("GAME START"));
-                startActions.Add(CreateGameAction("HALF START"));
+                startActions.Add(CreateGameAction(PlayType.GameStart));
+                startActions.Add(CreateGameAction(PlayType.HalfStart));
             }
             else if (period.PeriodNumber == 3)
             {
-                startActions.Add(CreateGameAction("HALF START"));
+                startActions.Add(CreateGameAction(PlayType.HalfStart));
             }
-            startActions.Add(CreateGameAction("PERIOD START"));
+            startActions.Add(CreateGameAction(PlayType.PeriodStart));
             AddPlayCard(startActions);
         }
     }
@@ -2580,16 +2580,26 @@ public class MainWindowViewModel : ViewModelBase
         };
     }
 
-    private PlayActionViewModel CreateGameAction(string action)
+    private PlayActionViewModel CreateGameAction(PlayType action)
     {
         Debug.WriteLine($"CreateGameAction: {action}");
+        string text = action switch
+        {
+            PlayType.GameStart => "GAME START",
+            PlayType.GameEnd => "GAME END",
+            PlayType.PeriodStart => "PERIOD START",
+            PlayType.PeriodEnd => "PERIOD END",
+            PlayType.HalfStart => "HALF START",
+            PlayType.HalfEnd => "HALF END",
+            _ => action.ToString().ToUpperInvariant()
+        };
         return new PlayActionViewModel
         {
             TeamColor = Brushes.Gray,
             PlayerNumber = string.Empty,
             FirstName = string.Empty,
             LastName = string.Empty,
-            Action = action
+            Action = text
         };
     }
 

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -588,6 +588,14 @@ public class MainWindowViewModel : ViewModelBase
         var period = Game.GetCurrentPeriod();
         period.Status = PeriodStatus.Ended;
 
+        var endActions = new List<PlayActionViewModel>
+        {
+            CreateGameAction("PERIOD END")
+        };
+        if (period.IsRegular && (period.PeriodNumber == 2 || period.PeriodNumber == Game.DefaultPeriods))
+            endActions.Add(CreateGameAction("HALF END"));
+        AddPlayCard(endActions);
+
         bool lastRegular = period.IsRegular && period.PeriodNumber == Game.DefaultPeriods;
         bool overtime = !period.IsRegular;
 
@@ -614,6 +622,7 @@ public class MainWindowViewModel : ViewModelBase
 
     private void OnFinalizeGameRequested()
     {
+        AddPlayCard(new[] { CreateGameAction("GAME END") });
         GameClockService.SetState("FINALIZED", false);
         IsGameFinalized = true;
         SelectedTabIndex = 2; // switch to Stats tab
@@ -626,6 +635,18 @@ public class MainWindowViewModel : ViewModelBase
         {
             period.Status = PeriodStatus.Active;
             GameClockService.SetPeriodDisplay($"{period.Name} - {period.Status}");
+            var startActions = new List<PlayActionViewModel>();
+            if (period.PeriodNumber == 1)
+            {
+                startActions.Add(CreateGameAction("GAME START"));
+                startActions.Add(CreateGameAction("HALF START"));
+            }
+            else if (period.PeriodNumber == 3)
+            {
+                startActions.Add(CreateGameAction("HALF START"));
+            }
+            startActions.Add(CreateGameAction("PERIOD START"));
+            AddPlayCard(startActions);
         }
     }
 
@@ -2554,6 +2575,19 @@ public class MainWindowViewModel : ViewModelBase
             TeamColor = teamA ? (Brush)_resources["CourtAColor"] : (Brush)_resources["CourtBColor"],
             PlayerNumber = string.Empty,
             FirstName = name,
+            LastName = string.Empty,
+            Action = action
+        };
+    }
+
+    private PlayActionViewModel CreateGameAction(string action)
+    {
+        Debug.WriteLine($"CreateGameAction: {action}");
+        return new PlayActionViewModel
+        {
+            TeamColor = Brushes.Gray,
+            PlayerNumber = string.Empty,
+            FirstName = string.Empty,
             LastName = string.Empty,
             Action = action
         };


### PR DESCRIPTION
## Summary
- extend play-by-play model with half start/end actions
- log game/period/half start and end events in the play-by-play log
- add helper to create game level log entries

## Testing
- `dotnet build StatsBB.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7d0c38fc83269dac7e825df13afc