### PR TITLE
Show fouls for current period

### DIFF
--- a/StatsBB/UserControls/TeamCardLeft.xaml
+++ b/StatsBB/UserControls/TeamCardLeft.xaml
@@ -31,7 +31,7 @@
                 </StackPanel>
                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0">
                     <Border Background="#EEE" CornerRadius="0" Padding="4" Margin="4,0,4,0">
-                        <TextBlock Text="{Binding TeamAFouls}" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding TeamAPeriodFouls}" FontSize="20" FontWeight="Bold"/>
                     </Border>
                 </StackPanel>
             </Grid>

--- a/StatsBB/UserControls/TeamCardRight.xaml
+++ b/StatsBB/UserControls/TeamCardRight.xaml
@@ -34,7 +34,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0">
                     <Border Background="#EEE" CornerRadius="0" Padding="4" Margin="4,0,4,0">
-                        <TextBlock Text="{Binding TeamBFouls}" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding TeamBPeriodFouls}" FontSize="20" FontWeight="Bold"/>
                     </Border>
                 </StackPanel>
                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">

--- a/StatsBB/ViewModel/GameStateViewModel.cs
+++ b/StatsBB/ViewModel/GameStateViewModel.cs
@@ -89,6 +89,21 @@ public class GameStateViewModel : ViewModelBase
 
     public string TeamBTimeoutsText => $"{TeamBTimeOutsLeft}/{TeamBTotalTimeouts}";
 
+    private int _teamAPeriodFouls;
+    /// <summary>
+    /// Fouls committed by Team A in the current period.
+    /// </summary>
+    public int TeamAPeriodFouls
+    {
+        get => _teamAPeriodFouls;
+        set
+        {
+            if (_teamAPeriodFouls == value) return;
+            _teamAPeriodFouls = value;
+            OnPropertyChanged();
+        }
+    }
+
     private int _teamAFouls;
     public int TeamAFouls
     {
@@ -97,6 +112,21 @@ public class GameStateViewModel : ViewModelBase
         {
             if (_teamAFouls == value) return;
             _teamAFouls = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private int _teamBPeriodFouls;
+    /// <summary>
+    /// Fouls committed by Team B in the current period.
+    /// </summary>
+    public int TeamBPeriodFouls
+    {
+        get => _teamBPeriodFouls;
+        set
+        {
+            if (_teamBPeriodFouls == value) return;
+            _teamBPeriodFouls = value;
             OnPropertyChanged();
         }
     }
@@ -116,9 +146,25 @@ public class GameStateViewModel : ViewModelBase
     public void AddFoul(bool teamA)
     {
         if (teamA)
+        {
             TeamAFouls++;
+            TeamAPeriodFouls++;
+        }
         else
+        {
             TeamBFouls++;
+            TeamBPeriodFouls++;
+        }
+    }
+
+    /// <summary>
+    /// Reset the period foul counters to zero.
+    /// Call this when a new period begins.
+    /// </summary>
+    public void ResetPeriodFouls()
+    {
+        TeamAPeriodFouls = 0;
+        TeamBPeriodFouls = 0;
     }
 }
 

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -577,6 +577,7 @@ public class MainWindowViewModel : ViewModelBase
         Game.InitializePeriods(Game.DefaultPeriods);
         Game.CurrentPeriod = 0;
         var period = Game.GetCurrentPeriod();
+        GameState.ResetPeriodFouls();
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Game");
         IsGamePanelVisible = false;
         IsStartingFiveButtonEnabled = true;
@@ -608,6 +609,7 @@ public class MainWindowViewModel : ViewModelBase
             period = Game.GetCurrentPeriod();
         }
 
+        GameState.ResetPeriodFouls();
         period.Status = PeriodStatus.Setup;
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Period");
     }

--- a/StatsBB/ViewModel/ScoreBoardViewModel.cs
+++ b/StatsBB/ViewModel/ScoreBoardViewModel.cs
@@ -54,6 +54,12 @@ public class ScoreBoardViewModel : ViewModelBase
             case nameof(GameStateViewModel.TeamBFouls):
                 OnPropertyChanged(nameof(TeamBFouls));
                 break;
+            case nameof(GameStateViewModel.TeamAPeriodFouls):
+                OnPropertyChanged(nameof(TeamAPeriodFouls));
+                break;
+            case nameof(GameStateViewModel.TeamBPeriodFouls):
+                OnPropertyChanged(nameof(TeamBPeriodFouls));
+                break;
         }
     }
 
@@ -63,6 +69,8 @@ public class ScoreBoardViewModel : ViewModelBase
     public string TeamBTimeoutsText => _main.GameState.TeamBTimeoutsText;
     public int TeamAFouls => _main.GameState.TeamAFouls;
     public int TeamBFouls => _main.GameState.TeamBFouls;
+    public int TeamAPeriodFouls => _main.GameState.TeamAPeriodFouls;
+    public int TeamBPeriodFouls => _main.GameState.TeamBPeriodFouls;
 
     public Brush TeamAColor => _main.TeamAColorOption?.ColorBrush ?? Brushes.Orange;
     public Brush TeamBColor => _main.TeamBColorOption?.ColorBrush ?? Brushes.Green;


### PR DESCRIPTION
## Summary
- track fouls per period in `GameStateViewModel`
- expose period foul counts through `ScoreBoardViewModel`
- display period fouls on team cards
- reset period foul counters when a new game or period begins

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7fb967848326913ab9b506affeb9