### PR TITLE
Fix technical foul free throw team selection

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1164,6 +1164,11 @@ public class MainWindowViewModel : ViewModelBase
             case "technical":
                 Debug.WriteLine($"Technical foul by {_foulCommiter?.Number}.{_foulCommiter?.Name}");
                 _defaultFreeThrows = 1;
+                if (_foulCommiter != null)
+                {
+                    // Technical fouls award free throws to the opposing team.
+                    _freeThrowTeamIsTeamA = !_foulCommiter.IsTeamA;
+                }
                 BeginFreeThrowsAwardedSelection();
                 break;
             default:


### PR DESCRIPTION
## Summary
- ensure technical fouls show the other team's players for free throws

## Testing
- `dotnet build StatsBB/StatsBB.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e80083fc88326951c6ac830ad1ab2