### PR TITLE
Clear shot markers for each new period

### DIFF
--- a/StatsBB/MainWindow.xaml.cs
+++ b/StatsBB/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace StatsBB
             vm.MarkerRequested += (pos, color, filled) => CourtControl.SetMarker(pos, color, filled);
             vm.TempMarkerRequested += (pos) => CourtControl.ShowTemporaryMarker(pos);
             vm.TempMarkerRemoved += () => CourtControl.RemoveTemporaryMarker();
+            vm.ClearMarkersRequested += () => CourtControl.ClearAllMarkers();
 
             // 📍 On canvas click: set point + show temp white marker
             CourtControl.CourtClick += (s, data) =>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -392,6 +392,7 @@ public class MainWindowViewModel : ViewModelBase
     public event Action<Point, Brush, bool>? MarkerRequested;
     public event Action<Point>? TempMarkerRequested;
     public event Action? TempMarkerRemoved;
+    public event Action? ClearMarkersRequested;
 
     public MainWindowViewModel(ResourceDictionary resources)
     {
@@ -578,6 +579,7 @@ public class MainWindowViewModel : ViewModelBase
         Game.CurrentPeriod = 0;
         var period = Game.GetCurrentPeriod();
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Game");
+        ClearMarkersRequested?.Invoke();
         IsGamePanelVisible = false;
         IsStartingFiveButtonEnabled = true;
         BeginStartingFive();
@@ -610,6 +612,7 @@ public class MainWindowViewModel : ViewModelBase
 
         period.Status = PeriodStatus.Setup;
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Period");
+        ClearMarkersRequested?.Invoke();
     }
 
     private void OnFinalizeGameRequested()


### PR DESCRIPTION
## Summary
- reset the court markers when a new period is setup
- expose `ClearMarkersRequested` event from `MainWindowViewModel`
- hook the event up in `MainWindow`

## Testing
- `dotnet build` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_687e804e1b5c8326a97a232c144a06c8