### PR TITLE
Add mass substitution feature

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1645,6 +1645,7 @@ Margin="4" />
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="30" />
                                         <RowDefinition Height="400" />
+                                        <RowDefinition Height="60" />
                                     </Grid.RowDefinitions>
                                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="16" FontWeight="Bold" Grid.Row="0" Grid.Column="1" Text="IN"/>
                                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="16" FontWeight="Bold" Grid.Row="0" Grid.Column="2" Text="OUT"/>
@@ -1816,6 +1817,10 @@ Margin="4" />
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
                                     </Border>
+
+                                    <!-- Sub Out All Buttons -->
+                                    <Button Grid.Row="2" Grid.Column="2" Content="5 OUT" Style="{StaticResource BlockStyle}" Command="{Binding SubOutAllTeamACommand}"/>
+                                    <Button Grid.Row="2" Grid.Column="6" Content="5 OUT" Style="{StaticResource BlockStyle}" Command="{Binding SubOutAllTeamBCommand}"/>
                                 </Grid>
                             </StackPanel>
                         </Grid>

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -366,6 +366,8 @@ public class MainWindowViewModel : ViewModelBase
     public ICommand ConfirmStartingFiveCommand { get; }
     public ICommand ToggleSubInCommand { get; }
     public ICommand ToggleSubOutCommand { get; }
+    public ICommand SubOutAllTeamACommand { get; }
+    public ICommand SubOutAllTeamBCommand { get; }
     public ICommand ToggleStartingFiveCommand { get; }
     public ICommand StartTimeoutCommand { get; }
     public ICommand TimeoutTeamACommand { get; }
@@ -452,6 +454,8 @@ public class MainWindowViewModel : ViewModelBase
         ConfirmStartingFiveCommand = new RelayCommand(_ => ConfirmStartingFive(), _ => IsStartingFiveConfirmEnabled);
         ToggleSubInCommand = new RelayCommand(p => ToggleSubIn(p as Player));
         ToggleSubOutCommand = new RelayCommand(p => ToggleSubOut(p as Player));
+        SubOutAllTeamACommand = new RelayCommand(_ => ToggleSubOutAll(true));
+        SubOutAllTeamBCommand = new RelayCommand(_ => ToggleSubOutAll(false));
         ToggleStartingFiveCommand = new RelayCommand(p => ToggleStartingFive(p as Player));
         StartTimeoutCommand = new RelayCommand(_ => BeginTimeout(), _ => !IsActionInProgress);
         TimeoutTeamACommand = new RelayCommand(_ => CompleteTimeoutSelection("Team A"), _ => IsTimeOutSelectionActive);
@@ -2367,6 +2371,25 @@ public class MainWindowViewModel : ViewModelBase
             list.Remove(player);
         else if (list.Count < 5)
             list.Add(player);
+
+        OnPropertyChanged(nameof(IsSubstitutionConfirmEnabled));
+    }
+
+    private void ToggleSubOutAll(bool isTeamA)
+    {
+        var targetList = isTeamA ? TeamASubOut : TeamBSubOut;
+        var courtPlayers = isTeamA ? TeamACourtPlayers : TeamBCourtPlayers;
+
+        if (targetList.Count == courtPlayers.Count && courtPlayers.All(p => targetList.Contains(p)))
+        {
+            targetList.Clear();
+        }
+        else
+        {
+            targetList.Clear();
+            foreach (var p in courtPlayers)
+                targetList.Add(p);
+        }
 
         OnPropertyChanged(nameof(IsSubstitutionConfirmEnabled));
     }


### PR DESCRIPTION
## Summary
- add commands to remove all players from the court for a team
- fix substitution panel layout and include new "5 OUT" buttons

## Testing
- `dotnet build StatsBB.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7c17a600832699c1337b3713d5aa