### PR TITLE
Reset fouls each period

### DIFF
--- a/StatsBB/ViewModel/GameStateViewModel.cs
+++ b/StatsBB/ViewModel/GameStateViewModel.cs
@@ -120,5 +120,15 @@ public class GameStateViewModel : ViewModelBase
         else
             TeamBFouls++;
     }
+
+    /// <summary>
+    /// Reset the foul counts for both teams. This should be called whenever a
+    /// new period begins.
+    /// </summary>
+    public void ResetFouls()
+    {
+        TeamAFouls = 0;
+        TeamBFouls = 0;
+    }
 }
 

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -577,6 +577,7 @@ public class MainWindowViewModel : ViewModelBase
         Game.InitializePeriods(Game.DefaultPeriods);
         Game.CurrentPeriod = 0;
         var period = Game.GetCurrentPeriod();
+        GameState.ResetFouls();
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Game");
         IsGamePanelVisible = false;
         IsStartingFiveButtonEnabled = true;
@@ -609,6 +610,7 @@ public class MainWindowViewModel : ViewModelBase
         }
 
         period.Status = PeriodStatus.Setup;
+        GameState.ResetFouls();
         GameClockService.Reset(period.Length, $"{period.Name} - {period.Status}", "Start Period");
     }
 


### PR DESCRIPTION
## Summary
- allow scoreboard to reset team fouls
- reset team fouls whenever a new game starts
- reset team fouls when advancing to the next period

## Testing
- `dotnet build StatsBB.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e804ca5d48326bb063e9325ef4100