### PR TITLE
Handle shot clock violation as team turnover

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1460,6 +1460,15 @@ public class MainWindowViewModel : ViewModelBase
             var shot = FormatShotAction(_pendingIsThreePoint, _wasBlocked ? "BLOCKED" : "MISSED");
             _currentPlayActions.Insert(0, CreateAction(_pendingShooter, shot));
             _actionProcessor.Process(ActionType.ShotMissed, _pendingShooter, null, _pendingIsThreePoint);
+
+            if (reboundSource is string r && r == "24")
+            {
+                bool teamA = _pendingShooter.IsTeamA;
+                _currentPlayActions.Add(CreateTeamAction(teamA, "TURNOVER"));
+                var team = teamA ? Game.HomeTeam : Game.AwayTeam;
+                _actionProcessor.ProcessTeam(ActionType.TeamTurnover, team);
+            }
+
             StatsVM.Refresh();
             AddPlayCard(_currentPlayActions.ToList());
             _currentPlayActions.Clear();


### PR DESCRIPTION
## Summary
- when the rebound panel's `24` button is pressed, record a team turnover for the shooter's team

## Testing
- `dotnet build StatsBB.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7c3e70e88326aa00d3d666294b80