### PR TITLE
Disable block button after block selection

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -438,9 +438,9 @@ public class MainWindowViewModel : ViewModelBase
         ReboundTeamACommand = new RelayCommand(_ => OnReboundTargetSelected("TeamA"), _ => IsReboundSelectionActive);
         ReboundTeamBCommand = new RelayCommand(_ => OnReboundTargetSelected("TeamB"), _ => IsReboundSelectionActive);
         BlockCommand = new RelayCommand(
-    _ => EnterBlockerSelection(),
-    _ => IsReboundSelectionActive
-);
+            _ => EnterBlockerSelection(),
+            _ => IsReboundSelectionActive && !_wasBlocked
+        );
         ShotClockCommand = new RelayCommand(_ => CompleteReboundSelection("24"), _ => IsReboundSelectionActive);
         TurnoverTeamACommand = new RelayCommand(_ => CompleteTurnoverSelection("TeamA"), _ => IsTurnoverSelectionActive);
         TurnoverTeamBCommand = new RelayCommand(_ => CompleteTurnoverSelection("TeamB"), _ => IsTurnoverSelectionActive);


### PR DESCRIPTION
## Summary
- when a block has already been selected, disable the Block button in the rebound panel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7cb8b3f0832689daaf0ef43ac1b6