### PR TITLE
Add action titles for various dialogs

### DIFF
--- a/StatsBB/MainWindow.xaml
+++ b/StatsBB/MainWindow.xaml
@@ -1027,7 +1027,9 @@ Margin="4" />
                             </StackPanel>
                         </Grid>
                         <Grid Visibility="{Binding FoulCommiterPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10" Height="500" Width="900">
-                            <Grid HorizontalAlignment="Center" VerticalAlignment="Center" Height="500">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding CurrentActionTitle}" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                                <Grid Height="500">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="160"/>
                                     <ColumnDefinition Width="100"/>
@@ -1133,9 +1135,11 @@ Margin="4" />
                                     </StackPanel>
                                 </Border>
                             </Grid>
+                            </StackPanel>
                         </Grid>
                         <Grid Visibility="{Binding FoulTypePanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10" Width="900" Height="500">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding CurrentActionTitle}" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
                                 <TextBlock Text="Foul Type" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="10"/>
                                 <WrapPanel HorizontalAlignment="Center" Width="900">
                                     <Button Style="{StaticResource FoulTypeButtonStyle}" Content="PERSONAL" Command="{Binding SelectFoulTypeCommand}" CommandParameter="personal"/>
@@ -1150,6 +1154,7 @@ Margin="4" />
                     </Grid>
                     <Grid Visibility="{Binding FreeThrowTeamPanelVisibility}" Background="#33FFFFFF" Panel.ZIndex="10">
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="White">
+                            <TextBlock Text="{Binding CurrentActionTitle}" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
                             <TextBlock Text="SELECT TEAM" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
                             <Grid>
                                 <Grid.ColumnDefinitions>
@@ -1167,6 +1172,7 @@ Margin="4" />
                     </Grid>
                     <Grid Visibility="{Binding FreeThrowsAwardedPanelVisibility}" Background="#ccFFFFFF" Panel.ZIndex="10">
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <TextBlock Text="{Binding CurrentActionTitle}" FontSize="32" FontWeight="Bold" HorizontalAlignment="Center" Margin="0 0 0 10"/>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Border Background="#cceeeeee" Padding="10" Margin="2">

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -794,6 +794,8 @@ public class MainWindowViewModel : ViewModelBase
             return;
         if (action.Equals("FOUL", StringComparison.InvariantCultureIgnoreCase))
         {
+            ResetSelectionState();
+            CurrentActionTitle = "FOUL";
             IsFoulCommiterSelectionActive = true;
         }
 


### PR DESCRIPTION
## Summary
- add `CurrentActionTitle` to `MainWindowViewModel` so each action dialog can show a title
- clear the title when exiting a dialog
- update selection handlers to set the title for shot made/missed, assist, rebound, steal, turnover and block actions
- display the title text in the Assist, Rebound, Steal, Block and Quick Shot panels

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8088c03483268f6f1ce55acce8bc