### PR TITLE
Block timeouts when none remain

### DIFF
--- a/StatsBB/ViewModel/GameStateViewModel.cs
+++ b/StatsBB/ViewModel/GameStateViewModel.cs
@@ -1,4 +1,5 @@
 using StatsBB.MVVM;
+using System.Windows.Input;
 
 namespace StatsBB.ViewModel;
 
@@ -43,6 +44,7 @@ public class GameStateViewModel : ViewModelBase
             _teamATimeOutsLeft = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(TeamATimeoutsText));
+            CommandManager.InvalidateRequerySuggested();
         }
     }
 
@@ -56,6 +58,7 @@ public class GameStateViewModel : ViewModelBase
             _teamATotalTimeouts = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(TeamATimeoutsText));
+            CommandManager.InvalidateRequerySuggested();
         }
     }
 
@@ -71,6 +74,7 @@ public class GameStateViewModel : ViewModelBase
             _teamBTimeOutsLeft = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(TeamBTimeoutsText));
+            CommandManager.InvalidateRequerySuggested();
         }
     }
 
@@ -84,6 +88,7 @@ public class GameStateViewModel : ViewModelBase
             _teamBTotalTimeouts = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(TeamBTimeoutsText));
+            CommandManager.InvalidateRequerySuggested();
         }
     }
 

--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -455,8 +455,12 @@ public class MainWindowViewModel : ViewModelBase
         ToggleSubOutCommand = new RelayCommand(p => ToggleSubOut(p as Player));
         ToggleStartingFiveCommand = new RelayCommand(p => ToggleStartingFive(p as Player));
         StartTimeoutCommand = new RelayCommand(_ => BeginTimeout(), _ => !IsActionInProgress);
-        TimeoutTeamACommand = new RelayCommand(_ => CompleteTimeoutSelection("Team A"), _ => IsTimeOutSelectionActive);
-        TimeoutTeamBCommand = new RelayCommand(_ => CompleteTimeoutSelection("Team B"), _ => IsTimeOutSelectionActive);
+        TimeoutTeamACommand = new RelayCommand(
+            _ => CompleteTimeoutSelection("Team A"),
+            _ => IsTimeOutSelectionActive && GameState.TeamATimeOutsLeft > 0);
+        TimeoutTeamBCommand = new RelayCommand(
+            _ => CompleteTimeoutSelection("Team B"),
+            _ => IsTimeOutSelectionActive && GameState.TeamBTimeOutsLeft > 0);
         StartJumpBallCommand = new RelayCommand(_ => BeginJumpBall(), _ => !IsActionInProgress);
         ToggleJumpPlayerCommand = new RelayCommand(p => ToggleJumpPlayer(p as Player));
         ConfirmJumpBallCommand = new RelayCommand(_ => ConfirmJumpBall(), _ => IsJumpEnabled);
@@ -2621,11 +2625,13 @@ public class MainWindowViewModel : ViewModelBase
         var period = Game.GetCurrentPeriod();
         if (teamA)
         {
+            if (GameState.TeamATimeOutsLeft == 0) return;
             Game.HomeTeam.AddTimeout(period);
             GameState.TeamATimeOutsLeft = Math.Max(0, GameState.TeamATimeOutsLeft - 1);
         }
         else
         {
+            if (GameState.TeamBTimeOutsLeft == 0) return;
             Game.AwayTeam.AddTimeout(period);
             GameState.TeamBTimeOutsLeft = Math.Max(0, GameState.TeamBTimeOutsLeft - 1);
         }


### PR DESCRIPTION
## Summary
- block teams from calling a timeout when they have none left
- refresh commands when timeout counts change

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8a51ec60832695be0d681ba101e4