### PR TITLE
Fix Escape Key on Timeout Panel

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1484,6 +1484,7 @@ public class MainWindowViewModel : ViewModelBase
         IsQuickShotSelectionActive = false;
         IsJumpBallChoicePanelVisible = false;
         IsJumpBallContestedPanelVisible = false;
+        IsTimeOutSelectionActive = false;
     }
 
     public void CancelCurrentAction()


### PR DESCRIPTION
## Summary
- cancel the timeout selection when escape is pressed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cad4b15408326809e6cb8f8f079fb