### PR TITLE
Disable block after free throws

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -479,7 +479,7 @@ public class MainWindowViewModel : ViewModelBase
         NoReboundCommand = new RelayCommand(_ => CompleteReboundSelection(null), _ => IsReboundSelectionActive);
         BlockCommand = new RelayCommand(
             _ => EnterBlockerSelection(),
-            _ => IsReboundSelectionActive && !_wasBlocked
+            _ => IsReboundSelectionActive && !_wasBlocked && !_pendingFreeThrowRebound
         );
         ShotClockCommand = new RelayCommand(_ => CompleteReboundSelection("24"), _ => IsReboundSelectionActive);
         TurnoverTeamACommand = new RelayCommand(_ => CompleteTurnoverSelection("TeamA"), _ => IsTurnoverSelectionActive);


### PR DESCRIPTION
## Summary
- prevent selecting Block during rebounds that come immediately after free throws

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cad03ce50832681f79942e737f813