### PR TITLE
Improve Escape key behavior for fouls

### DIFF
--- a/StatsBB/ViewModel/MainWindowViewModel.cs
+++ b/StatsBB/ViewModel/MainWindowViewModel.cs
@@ -1495,7 +1495,17 @@ public class MainWindowViewModel : ViewModelBase
             return;
 
         TempMarkerRemoved?.Invoke();
-        ResetSelectionState();
+
+        if (IsFoulCommiterSelectionActive || IsFoulTypeSelectionActive ||
+            IsFouledPlayerSelectionActive || IsFreeThrowTeamSelectionActive ||
+            IsFreeThrowsAwardedSelectionActive || IsFreeThrowsSelectionActive)
+        {
+            ResetFoulState();
+        }
+        else
+        {
+            ResetSelectionState();
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- handle ESC key for free throw/foul panels by calling `ResetFoulState`

## Testing
- `dotnet build StatsBB.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688caec546f08326b2004f21b1a5d451